### PR TITLE
feat: remove raw_message storage for flashblocks archiver

### DIFF
--- a/crates/flashblocks-archiver/migrations/001_initial_schema.sql
+++ b/crates/flashblocks-archiver/migrations/001_initial_schema.sql
@@ -19,7 +19,6 @@ CREATE TABLE IF NOT EXISTS flashblocks (
 
     block_number BIGINT NOT NULL,
     received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    raw_message JSONB NOT NULL,
     
     UNIQUE(builder_id, payload_id, flashblock_index)
 );

--- a/crates/flashblocks-archiver/src/types.rs
+++ b/crates/flashblocks-archiver/src/types.rs
@@ -4,7 +4,6 @@ use chrono::{DateTime, Utc};
 use reth_optimism_primitives::OpReceipt;
 use rollup_boost::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -41,7 +40,6 @@ pub struct Flashblock {
     pub flashblock_index: i64,
     pub block_number: i64,
     pub received_at: DateTime<Utc>,
-    pub raw_message: Value,
 }
 
 #[derive(Debug, sqlx::FromRow)]


### PR DESCRIPTION
DB would fill up too quickly due to how much data we're storing. This brings estimated storage down from 500 KB/s to ~100 KB/s for Base Mainnet

