### PR TITLE
chore(ci): Adds rustfmt.toml with the same rules as base/base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,10 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features
 
-  lint:
-    name: Lint
+  fmt:
+    name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
@@ -49,11 +50,41 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@0c3131df9e5407c0c36352032d04af846dbe0fb7 # nightly
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-on-failure: true
+          add-rust-environment-hash-key: "false"
+          key: nightly-${{ hashFiles('Cargo.lock') }}
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - run: just check-format
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
         with:
-          components: rustfmt, clippy
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-      - run: just lint
+          components: clippy
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-on-failure: true
+          add-rust-environment-hash-key: "false"
+          key: stable-${{ hashFiles('Cargo.lock') }}
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - run: just check-clippy
 
   docker:
     name: Docker Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,10 +1061,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -1094,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.55"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e34525d5bbbd55da2bb745d34b36121baac88d07619a9a09cfcf4a6c0832785"
+checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1104,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.55"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a20016a20a3da95bef50ec7238dbd09baeef4311dcdd38ec15aba69812fb61"
+checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1553,6 +1554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1958,7 +1965,6 @@ checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
- "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -1966,11 +1972,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1981,31 +1986,29 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.2"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -2015,8 +2018,6 @@ checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "serde",
- "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -3703,7 +3704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
- "serde_core",
  "zerovec",
 ]
 
@@ -4353,18 +4353,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.35"
+version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
+checksum = "dafd85c832c1b68bbb4ec0c72c7f6f4fc5179627d2bc7c26b30e4c0cc11e76cc"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.35"
+version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
+checksum = "7cb7e4e8436d9db52fbd6625dbf2f45243ab84994a72882ec8227b99e72b439a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4429,7 +4429,6 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
- "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/crates/mempool-rebroadcaster/src/main.rs
+++ b/crates/mempool-rebroadcaster/src/main.rs
@@ -1,9 +1,8 @@
 use clap::Parser;
 use dotenvy::dotenv;
-use tracing::{error, info, Level};
-use tracing_subscriber::EnvFilter;
-
 use mempool_rebroadcaster::rebroadcaster::Rebroadcaster;
+use tracing::{Level, error, info};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "A mempool rebroadcaster service")]

--- a/crates/mempool-rebroadcaster/tests/e2e_tests.rs
+++ b/crates/mempool-rebroadcaster/tests/e2e_tests.rs
@@ -1,6 +1,7 @@
+use std::path::Path;
+
 use alloy_rpc_types::txpool::TxpoolContent;
 use mempool_rebroadcaster::rebroadcaster::Rebroadcaster;
-use std::path::Path;
 
 fn load_static_mempool_content<P: AsRef<Path>>(
     filepath: P,
@@ -97,16 +98,10 @@ async fn test_e2e_filtering_logic() {
     );
 
     // Assert all transactions are filtered out due to high base fee
-    let total_pending = filtered_geth_mempool
-        .pending
-        .values()
-        .map(|nonce_txs| nonce_txs.len())
-        .sum::<usize>();
-    let total_queued = filtered_geth_mempool
-        .queued
-        .values()
-        .map(|nonce_txs| nonce_txs.len())
-        .sum::<usize>();
+    let total_pending =
+        filtered_geth_mempool.pending.values().map(|nonce_txs| nonce_txs.len()).sum::<usize>();
+    let total_queued =
+        filtered_geth_mempool.queued.values().map(|nonce_txs| nonce_txs.len()).sum::<usize>();
 
     assert_eq!(
         0,

--- a/crates/sidecrush/src/blockbuilding_healthcheck/alloy_client.rs
+++ b/crates/sidecrush/src/blockbuilding_healthcheck/alloy_client.rs
@@ -1,7 +1,8 @@
-use super::{EthClient, HeaderSummary};
 use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
+
+use super::{EthClient, HeaderSummary};
 
 #[derive(Clone)]
 pub struct AlloyEthClient {
@@ -10,9 +11,8 @@ pub struct AlloyEthClient {
 
 impl AlloyEthClient {
     pub fn new_http(url: &str) -> anyhow::Result<Self> {
-        let provider = ProviderBuilder::new()
-            .disable_recommended_fillers()
-            .connect_http(url.parse()?);
+        let provider =
+            ProviderBuilder::new().disable_recommended_fillers().connect_http(url.parse()?);
         Ok(Self { provider })
     }
 }
@@ -33,10 +33,6 @@ impl EthClient for AlloyEthClient {
         let timestamp_unix_seconds: u64 = block.header.timestamp;
         let transaction_count: usize = block.transactions.len();
 
-        Ok(HeaderSummary {
-            number,
-            timestamp_unix_seconds,
-            transaction_count,
-        })
+        Ok(HeaderSummary { number, timestamp_unix_seconds, transaction_count })
     }
 }

--- a/crates/sidecrush/src/metrics.rs
+++ b/crates/sidecrush/src/metrics.rs
@@ -1,5 +1,6 @@
-use cadence::{Counted, StatsdClient};
 use std::sync::Arc;
+
+use cadence::{Counted, StatsdClient};
 
 /// Metrics client wrapper for block building health checks
 /// Emits metrics every 2 seconds via status heartbeat (independent of poll frequency)
@@ -10,9 +11,7 @@ pub struct HealthcheckMetrics {
 
 impl HealthcheckMetrics {
     pub fn new(client: StatsdClient) -> Self {
-        Self {
-            client: Arc::new(client),
-        }
+        Self { client: Arc::new(client) }
     }
 
     /// Increment status_healthy counter (2s heartbeat)

--- a/justfile
+++ b/justfile
@@ -4,10 +4,28 @@ set dotenv-load := true
 # Default service name
 SERVICE := env_var_or_default("SERVICE", "mempool-rebroadcaster")
 
-# Run linting checks
-lint:
-    cargo fmt -- --check
-    cargo clippy --all-targets --all-features -- -D warnings
+# Runs all ci checks
+ci: fix test
+
+# Fixes formatting and clippy issues
+fix: format-fix clippy-fix
+
+# Checks formatting
+check-format:
+    cargo +nightly fmt --all -- --check
+
+# Fixes any formatting issues
+format-fix:
+    cargo fix --allow-dirty --allow-staged --workspace
+    cargo +nightly fmt --all
+
+# Checks clippy
+check-clippy:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Fixes any clippy issues
+clippy-fix:
+    cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged
 
 # Run tests
 test:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2024"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+use_small_heuristics = "Max"
+trailing_comma = "Vertical"
+use_field_init_shorthand = true


### PR DESCRIPTION
We add a rustfmt.toml files with the same rules as base/base to unify formatting styles between base/base and base/infra.