### PR TITLE
fix(ci): resolve runner stall on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
We see a runner stall on master even though CI works fine on pull requests. To fix this we now use github.ref for concurrency.