### PR TITLE
fix: handle EIP-4844 transactions in underpriced check

### DIFF
--- a/crates/mempool-rebroadcaster/src/rebroadcaster.rs
+++ b/crates/mempool-rebroadcaster/src/rebroadcaster.rs
@@ -3,7 +3,10 @@ use std::{collections::HashMap, error::Error};
 use alloy_consensus::Transaction;
 use alloy_eips::{
     Encodable2718,
-    eip2718::{EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP7702_TX_TYPE_ID, LEGACY_TX_TYPE_ID},
+    eip2718::{
+        EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
+        LEGACY_TX_TYPE_ID,
+    },
 };
 use alloy_primitives::B256;
 use alloy_provider::{Provider, ProviderBuilder, RootProvider, ext::TxPoolApi};
@@ -209,7 +212,7 @@ impl Rebroadcaster {
                 }
                 txn.gas_price().unwrap() < gas_price
             }
-            EIP1559_TX_TYPE_ID | EIP7702_TX_TYPE_ID => {
+            EIP1559_TX_TYPE_ID | EIP4844_TX_TYPE_ID | EIP7702_TX_TYPE_ID => {
                 if txn.max_priority_fee_per_gas().is_none() {
                     return true;
                 }


### PR DESCRIPTION
**Problem**

Previously, the is_underpriced function within the mempool-rebroadcaster crate did not explicitly account for EIP-4844 (Blob) transactions. As a result, any EIP-4844 transactions encountered were incorrectly categorized by the default _ match arm as "unknown transaction type" and subsequently treated as underpriced. This led to these transactions being filtered out from the mempool, preventing their proper rebroadcasting.

**Solution**

This Pull Request addresses the issue by updating the is_underpriced function in rebroadcaster.rs to correctly identify and process EIP-4844 transactions. The changes include:
Importing EIP4844_TX_TYPE_ID: The alloy_eips::eip2718 module now explicitly imports EIP4844_TX_TYPE_ID.
Updating is_underpriced logic: The EIP1559_TX_TYPE_ID match arm has been extended to include EIP4844_TX_TYPE_ID. This ensures that EIP-4844 transactions are evaluated based on their max_fee_per_gas against the base_fee, aligning their handling with other EIP-1559-like transactions.

**Impact**

This fix ensures that EIP-4844 transactions are no longer erroneously filtered out due to incorrect pricing assessment. By properly handling these transaction types, the mempool-rebroadcaster will maintain a more accurate representation of the mempool contents and facilitate the correct rebroadcasting of all supported transaction types, including Blob transactions.

**Testing**

Existing unit and end-to-end tests for the mempool-rebroadcaster crate were executed and passed successfully after applying this fix, confirming that the changes do not introduce regressions and the intended behavior for EIP-4844 transactions is now correctly implemented.
Branch: fix/handle-eip4844-txns