### PR TITLE
chore: adds tips-ingress-rpc service

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+[test-groups]
+# Limit concurrency for tests that spin up Docker containers (Kafka + MinIO)
+# to avoid resource contention causing container startup failures.
+container-tests = { max-threads = 4 }
+
+[[profile.default.overrides]]
+filter = 'binary_id(audit::s3_test) | binary_id(audit::integration_tests)'
+test-group = 'container-tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,14 +178,12 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@0c3131df9e5407c0c36352032d04af846dbe0fb7 # nightly
-        with:
-          components: rustfmt
+      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
           add-rust-environment-hash-key: "false"
-          key: nightly-${{ hashFiles('Cargo.lock') }}
+          key: stable-${{ hashFiles('Cargo.lock') }}
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just check-deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,4 +188,4 @@ jobs:
           key: nightly-${{ hashFiles('Cargo.lock') }}
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-      - run: just check-format
+      - run: just check-deny

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -57,7 +58,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "num_enum",
+ "serde",
  "strum 0.27.2",
 ]
 
@@ -81,11 +84,11 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -121,7 +124,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -150,7 +153,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -176,7 +179,7 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -209,10 +212,62 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_with",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b99ba7b74a87176f31ee1cd26768f7155b0eeff61ed925f59b13085ffe5f891"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-op-hardforks",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "op-alloy",
+ "op-revm",
+ "revm",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "borsh",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
 ]
 
 [[package]]
@@ -238,7 +293,7 @@ dependencies = [
  "http 1.4.0",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -265,7 +320,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -282,6 +337,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-op-evm"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "646a01ebc9778ee08bcc33cfa6714efc548f94e53de1aff6b34d9da55a2e5d41"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-op-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+ "op-alloy",
+ "op-revm",
+ "revm",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-op-hardforks"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6472c610150c4c4c15be9e1b964c9b78068f933bda25fb9cdf09b9ac2bb66f36"
+dependencies = [
+ "alloy-chains",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +378,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash 0.2.0",
+ "getrandom 0.3.4",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -341,7 +427,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -407,6 +493,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types-admin"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "564afceae126df73b95f78c81eb46e2ef689a45ace0fcdaf5c9a178693a5ccca"
+dependencies = [
+ "alloy-genesis",
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-rpc-types-any"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +527,8 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
@@ -453,7 +553,21 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -491,7 +605,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -507,7 +621,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -595,7 +709,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -635,7 +749,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -661,16 +775,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "aquamarine"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
+dependencies = [
+ "include_dir",
+ "itertools 0.10.5",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "arboard"
@@ -690,6 +862,51 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
 ]
 
 [[package]]
@@ -819,6 +1036,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,10 +1106,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
+ "ark-serialize-derive",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -882,12 +1155,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -948,7 +1248,7 @@ dependencies = [
  "metrics",
  "metrics-derive",
  "op-alloy-consensus 0.22.4",
- "op-alloy-rpc-types",
+ "op-alloy-rpc-types 0.22.4",
  "rdkafka",
  "serde",
  "serde_json",
@@ -975,6 +1275,16 @@ dependencies = [
  "tokio",
  "tracing",
  "utils",
+]
+
+[[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
 ]
 
 [[package]]
@@ -1406,6 +1716,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "tokio",
+]
+
+[[package]]
 name = "base-bundles"
 version = "0.0.0"
 source = "git+https://github.com/base/base?branch=main#f51543b2e9aff203743b67e68fc57f04c1637ce4"
@@ -1433,7 +1801,16 @@ dependencies = [
  "bytes",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "base-reth-rpc-types"
+version = "0.0.0"
+source = "git+https://github.com/base/base?branch=main#42851c399f968f81adcae8b430a22d39b14ff3a8"
+dependencies = [
+ "reth-optimism-evm",
+ "reth-rpc-eth-types",
 ]
 
 [[package]]
@@ -1567,6 +1944,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1576,6 +1956,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -1632,7 +2013,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1796,6 +2177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,8 +2244,10 @@ version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
 ]
 
 [[package]]
@@ -1898,6 +2287,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +2314,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2031,11 +2445,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -2109,6 +2539,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -2125,6 +2565,20 @@ checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core 0.23.0",
  "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2152,6 +2606,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -2198,6 +2663,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2709,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2332,6 +2826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2900,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "enr"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
+dependencies = [
+ "alloy-rlp",
+ "base64 0.22.1",
+ "bytes",
+ "hex",
+ "log",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,6 +2967,67 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ethereum_serde_utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
+dependencies = [
+ "alloy-primitives",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2549,6 +3127,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-map"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed19add84e8cb9e8cc5f7074de0324247149ffef0b851e215fb0edc50c229b"
+dependencies = [
+ "fixed-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "fixed-map-derive"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +3198,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fs_extra"
@@ -2748,9 +3353,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2837,6 +3444,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -3066,6 +3679,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
+ "log",
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -3301,6 +3915,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,6 +3966,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "ingress-rpc"
+version = "0.0.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer-local",
+ "anyhow",
+ "async-trait",
+ "audit",
+ "axum",
+ "backon",
+ "base-bundles",
+ "base-reth-rpc-types",
+ "clap",
+ "jsonrpsee",
+ "metrics",
+ "metrics-derive",
+ "mockall",
+ "moka",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-network 0.22.4",
+ "op-revm",
+ "rdkafka",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+ "utils",
+ "uuid",
+ "wiremock",
+]
+
+[[package]]
+name = "ingress-rpc-bin"
+version = "0.0.0"
+dependencies = [
+ "alloy-provider",
+ "anyhow",
+ "audit",
+ "base-bundles",
+ "clap",
+ "dotenvy",
+ "ingress-rpc",
+ "jsonrpsee",
+ "op-alloy-network 0.22.4",
+ "rdkafka",
+ "tokio",
+ "tracing",
+ "utils",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,6 +4046,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -3395,6 +4087,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +4126,121 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "jsonrpsee-types",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.2",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
+dependencies = [
+ "base64 0.22.1",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustls 0.23.36",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
+dependencies = [
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
+dependencies = [
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3571,6 +4400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,6 +4424,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -3621,7 +4462,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -3633,7 +4474,7 @@ dependencies = [
  "mempool-rebroadcaster",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -3672,7 +4513,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -3692,6 +4533,12 @@ dependencies = [
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -3719,6 +4566,73 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "modular-bitfield"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+dependencies = [
+ "modular-bitfield-impl",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -3768,12 +4682,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3789,6 +4726,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3926,6 +4885,29 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "op-alloy"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
+dependencies = [
+ "op-alloy-consensus 0.23.1",
+ "op-alloy-network 0.23.1",
+ "op-alloy-provider",
+ "op-alloy-rpc-types 0.23.1",
+ "op-alloy-rpc-types-engine",
+]
 
 [[package]]
 name = "op-alloy-consensus"
@@ -3935,12 +4917,14 @@ checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "alloy-serde",
  "derive_more",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3951,12 +4935,14 @@ checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "alloy-serde",
  "derive_more",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3964,6 +4950,53 @@ name = "op-alloy-flz"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
+
+[[package]]
+name = "op-alloy-network"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63f27e65be273ec8fcb0b6af0fd850b550979465ab93423705ceb3dfddbd2ab"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-rpc-types 0.22.4",
+]
+
+[[package]]
+name = "op-alloy-network"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "op-alloy-consensus 0.23.1",
+ "op-alloy-rpc-types 0.23.1",
+]
+
+[[package]]
+name = "op-alloy-provider"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6753d90efbaa8ea8bcb89c1737408ca85fa60d7adb875049d3f382c063666f86"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
+ "async-trait",
+ "op-alloy-rpc-types-engine",
+]
 
 [[package]]
 name = "op-alloy-rpc-types"
@@ -3981,7 +5014,59 @@ dependencies = [
  "op-alloy-consensus 0.22.4",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more",
+ "op-alloy-consensus 0.23.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "op-alloy-consensus 0.23.1",
+ "serde",
+ "sha2",
+ "snap",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-revm"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
+dependencies = [
+ "auto_impl",
+ "revm",
+ "serde",
 ]
 
 [[package]]
@@ -4054,7 +5139,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4083,6 +5168,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4109,6 +5206,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4188,6 +5291,49 @@ checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4282,6 +5428,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4289,6 +5461,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4398,6 +5579,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4504,6 +5740,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84816e4c99c467e92cf984ee6328caa976dfecd33a673544489d79ca2caaefe5"
 dependencies = [
+ "rand 0.9.2",
  "rustversion",
 ]
 
@@ -4535,6 +5772,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -4604,7 +5861,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4675,6 +5932,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -4682,6 +5940,9 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4689,6 +5950,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -4696,6 +5958,976 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "reth-chain-state"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "derive_more",
+ "metrics",
+ "parking_lot",
+ "pin-project",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-trie",
+ "revm-database",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-chainspec"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "auto_impl",
+ "derive_more",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-primitives-traits",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-codecs"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "bytes",
+ "modular-bitfield",
+ "op-alloy-consensus 0.23.1",
+ "reth-codecs-derive",
+ "reth-zstd-compressors",
+ "serde",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "reth-consensus"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "auto_impl",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-consensus-common"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-primitives-traits",
+]
+
+[[package]]
+name = "reth-db-models"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "bytes",
+ "reth-primitives-traits",
+ "serde",
+]
+
+[[package]]
+name = "reth-errors"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "reth-consensus",
+ "reth-execution-errors",
+ "reth-storage-errors",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-eth-wire-types"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-rlp",
+ "bytes",
+ "derive_more",
+ "reth-chainspec",
+ "reth-codecs-derive",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-ethereum-forks"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+ "once_cell",
+ "rustc-hash",
+]
+
+[[package]]
+name = "reth-ethereum-primitives"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "reth-primitives-traits",
+ "reth-zstd-compressors",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-evm"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "auto_impl",
+ "derive_more",
+ "futures-util",
+ "rayon",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "revm",
+]
+
+[[package]]
+name = "reth-execution-errors"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-rlp",
+ "nybbles",
+ "reth-storage-errors",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-execution-types"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "derive_more",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-trie-common",
+ "revm",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-fs-util"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-metrics"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "metrics",
+ "metrics-derive",
+]
+
+[[package]]
+name = "reth-net-banlist"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-primitives",
+ "ipnet",
+]
+
+[[package]]
+name = "reth-network-api"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rpc-types-admin",
+ "alloy-rpc-types-eth",
+ "auto_impl",
+ "derive_more",
+ "enr",
+ "futures",
+ "reth-eth-wire-types",
+ "reth-ethereum-forks",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-tokio-util",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "reth-network-p2p"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "auto_impl",
+ "derive_more",
+ "futures",
+ "reth-consensus",
+ "reth-eth-wire-types",
+ "reth-ethereum-primitives",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-primitives-traits",
+ "reth-storage-errors",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-network-peers"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "secp256k1 0.30.0",
+ "serde_with",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "reth-network-types"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-eip2124",
+ "reth-net-banlist",
+ "reth-network-peers",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-chainspec"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "derive_more",
+ "miniz_oxide",
+ "op-alloy-consensus 0.23.1",
+ "op-alloy-rpc-types 0.23.1",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-optimism-consensus"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-trie",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-execution-types",
+ "reth-optimism-chainspec",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "revm",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-evm"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-op-evm",
+ "alloy-primitives",
+ "op-alloy-consensus 0.23.1",
+ "op-alloy-rpc-types-engine",
+ "op-revm",
+ "reth-chainspec",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-optimism-chainspec",
+ "reth-optimism-consensus",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "reth-storage-errors",
+ "revm",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-optimism-forks"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-op-hardforks",
+ "alloy-primitives",
+ "once_cell",
+ "reth-ethereum-forks",
+]
+
+[[package]]
+name = "reth-optimism-primitives"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "op-alloy-consensus 0.23.1",
+ "reth-primitives-traits",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-trie",
+ "auto_impl",
+ "bytes",
+ "derive_more",
+ "once_cell",
+ "op-alloy-consensus 0.23.1",
+ "reth-codecs",
+ "revm-bytecode",
+ "revm-primitives",
+ "revm-state",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-prune-types"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "serde",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-revm"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-primitives",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "revm",
+]
+
+[[package]]
+name = "reth-rpc-convert"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-evm",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "auto_impl",
+ "dyn-clone",
+ "jsonrpsee-types",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-rpc-eth-types"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "derive_more",
+ "futures",
+ "itertools 0.14.0",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "metrics",
+ "rand 0.9.2",
+ "reqwest",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-revm",
+ "reth-rpc-convert",
+ "reth-rpc-server-types",
+ "reth-storage-api",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "reth-trie",
+ "revm",
+ "revm-inspectors",
+ "schnellru",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "reth-rpc-server-types"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "reth-errors",
+ "reth-network-api",
+ "serde",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "reth-stages-types"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-primitives",
+ "bytes",
+ "reth-trie-common",
+ "serde",
+]
+
+[[package]]
+name = "reth-static-file-types"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "fixed-map",
+ "serde",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "reth-storage-api"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "reth-chainspec",
+ "reth-db-models",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "revm-database",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-storage-errors"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-static-file-types",
+ "revm-database-interface",
+ "revm-state",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-tasks"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "auto_impl",
+ "dyn-clone",
+ "futures-util",
+ "metrics",
+ "reth-metrics",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "reth-tokio-util"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-transaction-pool"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "aquamarine",
+ "auto_impl",
+ "bitflags 2.10.0",
+ "futures-util",
+ "metrics",
+ "parking_lot",
+ "pin-project",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-eth-wire-types",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
+ "reth-fs-util",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-tasks",
+ "revm-interpreter",
+ "revm-primitives",
+ "rustc-hash",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "auto_impl",
+ "itertools 0.14.0",
+ "reth-execution-errors",
+ "reth-primitives-traits",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "reth-trie-sparse",
+ "revm-database",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie-common"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-trie",
+ "arrayvec",
+ "bytes",
+ "derive_more",
+ "itertools 0.14.0",
+ "nybbles",
+ "rayon",
+ "reth-primitives-traits",
+ "revm-database",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-trie-sparse"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "auto_impl",
+ "reth-execution-errors",
+ "reth-primitives-traits",
+ "reth-trie-common",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "reth-zstd-compressors"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
+dependencies = [
+ "zstd",
+]
+
+[[package]]
+name = "revm"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+dependencies = [
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+dependencies = [
+ "alloy-eips",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "revm-handler"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-inspectors"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e435414e9de50a1b930da602067c76365fea2fea11e80ceb50783c94ddd127f"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
+ "alloy-sol-types",
+ "anstyle",
+ "colorchoice",
+ "revm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+dependencies = [
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1 0.31.1",
+ "sha2",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.10.0",
+ "revm-bytecode",
+ "revm-primitives",
+ "serde",
 ]
 
 [[package]]
@@ -4723,6 +6955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4731,6 +6972,12 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
+
+[[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "ruint"
@@ -4771,6 +7018,9 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -4841,6 +7091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4876,8 +7127,36 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4926,6 +7205,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,6 +7244,17 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schnellru"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -4997,8 +7296,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.2",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -5006,6 +7316,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -5106,11 +7425,23 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5267,7 +7598,7 @@ dependencies = [
  "cadence",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -5279,7 +7610,7 @@ dependencies = [
  "sidecrush",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -5337,9 +7668,15 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -5363,6 +7700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5380,6 +7723,22 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
 ]
 
 [[package]]
@@ -5537,6 +7896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5554,6 +7919,12 @@ dependencies = [
  "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testcontainers"
@@ -5576,7 +7947,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tar",
@@ -5595,11 +7966,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5685,6 +8076,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5793,6 +8199,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5906,6 +8313,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5928,7 +8345,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
  "web-time",
 ]
 
@@ -5939,6 +8356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -5981,7 +8407,7 @@ dependencies = [
  "native-tls",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -6100,6 +8526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "utils"
 version = "0.0.0"
 dependencies = [
@@ -6107,7 +8539,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "serde_json",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6154,6 +8586,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -6317,6 +8759,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.6",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6337,6 +8797,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -6405,6 +8874,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6446,6 +8924,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6498,6 +8991,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6516,6 +9015,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6531,6 +9036,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6564,6 +9075,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6579,6 +9096,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6600,6 +9123,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6615,6 +9144,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6641,6 +9176,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -6901,6 +9459,24 @@ name = "zmij"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
 
 [[package]]
 name = "zstd-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86debde32d8dbb0ab29e7cc75ae1a98688ac7a4c9da54b3a9b14593b9b3c46d3"
+checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -78,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6cb2e7efd385b333f5a77b71baaa2605f7e22f1d583f2879543b54cbce777c"
+checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -92,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668859fcdb42eee289de22a9d01758c910955bb6ecda675b97276f99ce2e16b0"
+checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -162,6 +174,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
+ "k256",
  "serde",
  "thiserror",
 ]
@@ -180,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be47bf1b91674a5f394b9ed3c691d764fb58ba43937f1371550ff4bc8e59c295"
+checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -216,13 +229,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a24c81a56d684f525cd1c012619815ad3a1dd13b0238f069356795d84647d3c"
+checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -231,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786c5b3ad530eaf43cda450f973fe7fb1c127b4c8990adf66709dafca25e3f6f"
+checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -257,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ed40adf21ae4be786ef5eb62db9c692f6a30f86d34452ca3f849d6390ce319"
+checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -297,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ca4c15818be7ac86208aff3a91b951d14c24e1426e66624e75f2215ba5e2cc"
+checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -359,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe0addad5b8197e851062b49dc47157444bced173b601d91e3f9b561a060a50"
+checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -382,11 +395,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d17d4645a717f0527e491f44f6f7a75c221b9c00ccf79ddba2d26c8e0df4c3"
+checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-txpool",
  "alloy-serde",
  "serde",
@@ -394,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e98aabb013a71a4b67b52825f7b503e5bb6057fb3b7b2290d514b0b0574b57"
+checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -405,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc871ae69688e358cf242a6a7ee6b6e0476a03fd0256434c68daedaec086ec4"
+checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -423,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5899af8417dcf89f40f88fa3bdb2f3f172605d8e167234311ee34811bbfdb0bf"
+checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -444,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8074654c0292783d504bfa1f2691a69f420154ee9a7883f9212eaf611e60cd"
+checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -456,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb73325ee881e42972a5a7bc85250f6af89f92c6ad1222285f74384a203abeb"
+checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -467,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bea4c8f30eddb11d7ab56e83e49c814655daa78ca708df26c300c10d0189cbc"
+checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -477,6 +491,22 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
  "thiserror",
 ]
 
@@ -552,13 +582,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b321f506bd67a434aae8e8a7dfe5373bf66137c149a5f09c9e7dfb0ca43d7c91"
+checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
- "base64",
+ "base64 0.22.1",
  "derive_more",
  "futures",
  "futures-utils-wasm",
@@ -575,12 +605,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bf12879a20e1261cd39c3b101856f52d18886907a826e102538897f0d2b66e"
+checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
+ "itertools 0.14.0",
  "opentelemetry",
  "opentelemetry-http",
  "reqwest",
@@ -610,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a91d6b4c2f6574fdbcb1611e460455c326667cf5b805c6bd1640dad8e8ee4d2"
+checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -630,54 +661,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "anyhow"
@@ -943,6 +930,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audit"
+version = "0.0.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer-local",
+ "anyhow",
+ "async-trait",
+ "audit",
+ "aws-config",
+ "aws-sdk-s3",
+ "base-bundles",
+ "bytes",
+ "futures",
+ "metrics",
+ "metrics-derive",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-rpc-types",
+ "rdkafka",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+ "utils",
+ "uuid",
+]
+
+[[package]]
+name = "audit-bin"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "audit",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-s3",
+ "clap",
+ "dotenvy",
+ "rdkafka",
+ "tokio",
+ "tracing",
+ "utils",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,9 +995,435 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c456581cb3c77fafcc8c67204a70680d40b61112d6da78c77bd31d945b65f1b5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.3",
+ "aws-smithy-json 0.62.3",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 1.4.0",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c635c2dc792cb4a11ce1a4f392a925340d1bdf499289b5ec1ec6810954eb43f5"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.3",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.119.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "lru 0.12.5",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6443ccadc777095d5ed13e21f5c364878c9f5bad4e35187a6cdbd863b0afcad"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.3",
+ "aws-smithy-json 0.62.3",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa49f3c607b92daae0c078d48a4571f599f966dce3caee5f1ea55c4d9073f99"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.3",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52eec3db979d18cb807fc1070961cc51d87d069abe9ab57917769687368a8c6c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.63.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+dependencies = [
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b9c7354a3b13c66f60fe4616d6d1969c9fd36b1b5333a5dfb3ee716b33c588"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630e67f2a31094ffa51b210ae030855cb8f3b7ee1329bdd8d085aaf61e8b97fc"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12fb0abf49ff0cab20fd31ac1215ed7ce0ea92286ba09e2854b42ba5cabe7525"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb96aa208d62ee94104645f7b2ecaf77bf27edf161590b6224bfbac2832f979"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a46543fbc94621080b3cf553eb4cbbdc41dd9780a30c4756400f0139440a1d"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cebbddb6f3a5bd81553643e9c7daf3cc3dc5b0b5f398ac668630e8a84e6fff0"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3df87c14f0127a0d77eb261c3bc45d5b4833e2a1f63583ebfb728e4852134ee"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.3",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49952c52f7eebb72ce2a754d3866cc0f87b97d2a46146b79f80f3a93fb2b3716"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3a26048eeab0ddeba4b4f9d51654c79af8c3b32357dc5f336cee85ab331c33"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version 0.4.1",
+ "tracing",
+]
+
+[[package]]
+name = "base-bundles"
+version = "0.0.0"
+source = "git+https://github.com/base/base?branch=main#f51543b2e9aff203743b67e68fc57f04c1637ce4"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-serde",
+ "op-alloy-consensus 0.23.1",
+ "op-alloy-flz",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "base-flashtypes"
 version = "0.0.0"
-source = "git+https://github.com/base/base.git#720f6e1a73faabc938402b0cb617d3960db742d4"
+source = "git+https://github.com/base/base.git#f51543b2e9aff203743b67e68fc57f04c1637ce4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -983,9 +1444,25 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -1031,6 +1508,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1555,12 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1098,6 +1599,56 @@ dependencies = [
  "glob",
  "threadpool",
  "zeroize",
+]
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-named-pipe",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
 ]
 
 [[package]]
@@ -1184,6 +1735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "c-kzg"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3075f133bee430b7644c54fb629b9b4420346ffa275a45c81a6babe8b09b4f51"
+checksum = "d7aff0c323415907f37007d645d7499c378df47efb3e33ffc1f397fa4e549b2e"
 dependencies = [
  "crossbeam-channel",
 ]
@@ -1229,7 +1790,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1259,6 +1831,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,10 +1857,8 @@ version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
 ]
 
 [[package]]
@@ -1308,10 +1889,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.4"
+name = "cmake"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "compact_str"
@@ -1385,6 +1969,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +2009,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "rand 0.9.2",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +2040,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,7 +2060,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1683,7 +2299,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "objc2",
 ]
 
@@ -1696,6 +2312,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1815,6 +2442,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +2517,17 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1950,6 +2599,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2099,6 +2754,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2781,44 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2199,6 +2905,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,12 +2936,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2226,8 +2963,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2236,6 +2973,36 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -2247,15 +3014,64 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "hyper-util",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
 ]
 
 [[package]]
@@ -2266,7 +3082,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2280,21 +3096,36 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2401,6 +3232,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2525,12 +3362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +3395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,7 +3420,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -2628,10 +3469,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.181"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -2645,8 +3502,21 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
+ "redox_syscall 0.7.0",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2721,6 +3591,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +3621,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2754,6 +3635,69 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a87f4b19620e4c561f7b48f5e6ca085b1780def671696a6a3d9d0c137360ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "indexmap 2.13.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2796,12 +3740,22 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2874,6 +3828,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -2908,7 +3863,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -2920,7 +3875,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "dispatch2",
  "objc2",
 ]
@@ -2931,7 +3886,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2950,7 +3905,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2961,7 +3916,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2973,10 +3928,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
+name = "op-alloy-consensus"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "op-alloy-flz"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562dd4462562c41f9fdc4d860858c40e14a25df7f983ae82047f15f08fce4d19"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more",
+ "op-alloy-consensus 0.22.4",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "openssl"
@@ -2984,7 +3990,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3011,6 +4017,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +4039,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3044,7 +4066,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.4.0",
  "opentelemetry",
 ]
 
@@ -3053,6 +4075,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parity-scale-codec"
@@ -3100,9 +4128,34 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3117,7 +4170,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3191,12 +4244,18 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -3220,6 +4279,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3281,7 +4350,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -3299,6 +4368,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -3406,10 +4490,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rapidhash"
-version = "4.2.2"
+name = "rand_xoshiro"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ec30b38a417407efe7676bad0ca6b78f995f810185ece9af3bd5dc561185a9"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84816e4c99c467e92cf984ee6328caa976dfecd33a673544489d79ca2caaefe5"
 dependencies = [
  "rustversion",
 ]
@@ -3420,7 +4513,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -3436,12 +4529,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.10.0+2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "openssl-sys",
+ "pkg-config",
+ "zstd-sys",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -3476,6 +4628,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +4649,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -3498,13 +4668,13 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -3632,7 +4802,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3645,11 +4815,59 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3659,6 +4877,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3681,9 +4921,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
@@ -3723,6 +4963,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -3766,8 +5016,21 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
- "core-foundation",
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3851,6 +5114,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,7 +5142,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3926,6 +5200,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -3987,6 +5267,7 @@ dependencies = [
  "cadence",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4061,6 +5342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4073,6 +5360,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4112,6 +5409,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "strum"
@@ -4224,15 +5544,53 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -4340,7 +5698,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4367,6 +5725,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.36",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4376,6 +5754,21 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -4456,11 +5849,11 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -4582,7 +5975,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "native-tls",
@@ -4624,9 +6017,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4689,6 +6082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,10 +6100,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
+name = "utils"
+version = "0.0.0"
+dependencies = [
+ "alloy-rpc-types",
+ "metrics-exporter-prometheus",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "uuid"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "serde_core",
+ "sha1_smol",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -4723,6 +6140,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -4753,6 +6176,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -4814,6 +6246,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -4939,6 +6405,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4971,6 +6446,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5008,6 +6498,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5020,6 +6516,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5029,6 +6531,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5056,6 +6564,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5065,6 +6579,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5080,6 +6600,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5089,6 +6615,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5116,6 +6648,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -5148,6 +6762,22 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.3",
+]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
@@ -5268,9 +6898,20 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,19 @@
+
+
+[workspace.package]
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.88"
+license = "MIT"
+homepage = "https://github.com/base/infra"
+repository = "https://github.com/base/infra"
+exclude = [".github/"]
+
 [workspace]
 resolver = "2"
 members = ["crates/*", "bin/*"]
 default-members = ["bin/*"]
 exclude = [".github/"]
-
-[workspace.package]
-version = "0.0.0"
-edition = "2024"
-license = "MIT"
 
 [workspace.lints.rust]
 missing-debug-implementations = "warn"
@@ -44,42 +50,36 @@ needless-pass-by-ref-mut = "warn"
 string-lit-as-bytes = "warn"
 
 [workspace.dependencies]
-cadence = "1.4"
-clap = { version = "4.0", features = ["derive", "env"] }
-tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
-futures-util = "0.3"
-url = "2.5"
-ratatui = "0.29"
-crossterm = "0.28"
-chrono = "0.4"
-anyhow = "1.0"
-serde_yaml = "0.9"
-dirs = "6.0"
-arboard = "3.4"
-dotenvy = "0.15.7"
-async-trait = "0.1"
-mempool-rebroadcaster = { path = "./crates/mempool-rebroadcaster" }
-sidecrush = { path = "./crates/sidecrush" }
-metrics = "0.24.1"
-metrics-derive = "0.1"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi", "json"] }
-tokio = { version = "1.0", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+# Internal crates
+audit = { path = "crates/audit" }
+basectl-cli = { path = "crates/basectl" }
+mempool-rebroadcaster = { path = "crates/mempool-rebroadcaster" }
+sidecrush = { path = "crates/sidecrush" }
+utils = { path = "crates/utils" }
+
+# base-reth
+base-bundles = { git = "https://github.com/base/base", branch = "main" }
+base-flashtypes = { git = "https://github.com/base/base.git" }
+base-reth-rpc-types = { git = "https://github.com/base/base", branch = "main" }
+
+# revm
+op-revm = { version = "15.0.0", default-features = false }
+revm-context-interface = { version = "15.0.0", default-features = false }
 
 # alloy
-alloy-primitives = { version = "1.5.2", default-features = false, features = [
-    "map-foldhash",
-] }
-alloy-genesis = { version = "1.5.2", default-features = false }
-alloy-eips = { version = "1.5.2", default-features = false }
-alloy-rpc-types = { version = "1.5.2", default-features = false }
-alloy-rpc-types-engine = { version = "1.5.2", default-features = false }
-alloy-rpc-types-eth = { version = "1.5.2" }
-alloy-consensus = { version = "1.5.2" }
+alloy-serde = { version = "1.0.41", default-features = false }
+alloy-signer = { version = "1.0.41", default-features = false }
+alloy-network = { version = "1.0.41", default-features = false }
+alloy-provider = { version = "1.0.41", default-features = false }
+alloy-consensus = { version = "1.0.41", default-features = false }
+alloy-rpc-types = { version = "1.1.2", default-features = false }
+alloy-primitives = { version = "1.4.1", default-features = false }
+alloy-signer-local = { version = "1.0.41", default-features = false }
+alloy-genesis = { version = "1.0.41", default-features = false }
+alloy-eips = { version = "1.0.41", default-features = false }
+alloy-rpc-types-engine = { version = "1.0.41", default-features = false }
+alloy-rpc-types-eth = { version = "1.0.41" }
 alloy-trie = { version = "0.9.1", default-features = false }
-alloy-provider = { version = "1.5.2" }
 alloy-hardforks = { version = "0.5" }
 alloy-rpc-client = { version = "1.5.2" }
 alloy-transport-http = { version = "1.5.2" }
@@ -87,10 +87,54 @@ alloy-sol-types = { version = "1.5.2" }
 alloy-contract = { version = "1.5.2" }
 
 # op-alloy
+op-alloy-flz = { version = "0.13.1", default-features = false }
+op-alloy-network = { version = "0.22.0", default-features = false }
 op-alloy-rpc-types = { version = "0.22.0", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.22.0", default-features = false }
 op-alloy-consensus = { version = "0.22.0", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.22.0", default-features = false }
 
-# base
-base-flashtypes = { git = "https://github.com/base/base.git" }
-basectl-cli = { path = "crates/basectl" }
+# tokio
+tokio = { version = "1.47.1", features = ["full"] }
+
+# async
+async-trait = "0.1.89"
+futures = { version = "0.3.31", default-features = false }
+futures-util = "0.3"
+
+# rpc
+jsonrpsee = { version = "0.26.0", default-features = false }
+
+# kafka and s3
+bytes = { version = "1.8.0", default-features = false }
+rdkafka = { version = "0.37.0", default-features = false }
+aws-config = { version = "1.1.7", default-features = false }
+aws-sdk-s3 = { version = "1.106.0", default-features = false }
+aws-credential-types = { version = "1.1.7", default-features = false }
+
+# misc
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
+url = { version = "2.5.7", default-features = false }
+axum = { version = "0.8.3", default-features = false }
+ratatui = "0.29"
+crossterm = "0.28"
+clap = { version = "4.5.47", default-features = false, features = ["std", "derive", "env"] }
+chrono = "0.4"
+anyhow = { version = "1.0.99", default-features = false }
+serde = { version = "1.0.219", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.143", default-features = false }
+serde_yaml = "0.9"
+uuid = { version = "1.18.1", default-features = false }
+backon = { version = "1.5.2", default-features = false }
+dirs = "6.0"
+arboard = "3.4"
+dotenvy = { version = "0.15.7", default-features = false }
+tracing = { version = "0.1.41", default-features = false }
+tracing-subscriber = { version = "0.3.20", default-features = false, features = ["env-filter", "fmt", "ansi", "json"] }
+wiremock = { version = "0.6.2", default-features = false }
+metrics = { version = "0.24.1", default-features = false }
+metrics-derive = { version = "0.1", default-features = false }
+metrics-exporter-prometheus = { version = "0.17.0", default-features = false }
+testcontainers = { version = "0.23.1", default-features = false }
+testcontainers-modules = { version = "0.11.2", default-features = false }
+moka = { version = "0.12.12", default-features = false }
+cadence = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ basectl-cli = { path = "crates/basectl" }
 mempool-rebroadcaster = { path = "crates/mempool-rebroadcaster" }
 sidecrush = { path = "crates/sidecrush" }
 utils = { path = "crates/utils" }
+ingress-rpc = { path = "crates/ingress-rpc" }
 
 # base-reth
 base-bundles = { git = "https://github.com/base/base", branch = "main" }

--- a/bin/audit/Cargo.toml
+++ b/bin/audit/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "audit-bin"
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "audit"
+path = "src/main.rs"
+
+[dependencies]
+utils.workspace = true
+audit.workspace = true
+clap.workspace = true
+tokio.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+dotenvy.workspace = true
+rdkafka.workspace = true
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
+aws-credential-types.workspace = true

--- a/bin/audit/src/main.rs
+++ b/bin/audit/src/main.rs
@@ -1,0 +1,135 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use audit::{KafkaAuditArchiver, KafkaAuditLogReader, S3EventReaderWriter, create_kafka_consumer};
+use aws_config::{BehaviorVersion, Region};
+use aws_credential_types::Credentials;
+use aws_sdk_s3::{Client as S3Client, config::Builder as S3ConfigBuilder};
+use clap::{Parser, ValueEnum};
+use rdkafka::consumer::Consumer;
+use tracing::info;
+use utils::{logger::init_logger_with_format, metrics::init_prometheus_exporter};
+
+#[derive(Debug, Clone, ValueEnum)]
+enum S3ConfigType {
+    Aws,
+    Manual,
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(long, env = "TIPS_AUDIT_KAFKA_PROPERTIES_FILE")]
+    kafka_properties_file: String,
+
+    #[arg(long, env = "TIPS_AUDIT_KAFKA_TOPIC")]
+    kafka_topic: String,
+
+    #[arg(long, env = "TIPS_AUDIT_S3_BUCKET")]
+    s3_bucket: String,
+
+    #[arg(long, env = "TIPS_AUDIT_LOG_LEVEL", default_value = "info")]
+    log_level: String,
+
+    #[arg(long, env = "TIPS_AUDIT_LOG_FORMAT", default_value = "pretty")]
+    log_format: utils::logger::LogFormat,
+
+    #[arg(long, env = "TIPS_AUDIT_S3_CONFIG_TYPE", default_value = "aws")]
+    s3_config_type: S3ConfigType,
+
+    #[arg(long, env = "TIPS_AUDIT_S3_ENDPOINT")]
+    s3_endpoint: Option<String>,
+
+    #[arg(long, env = "TIPS_AUDIT_S3_REGION", default_value = "us-east-1")]
+    s3_region: String,
+
+    #[arg(long, env = "TIPS_AUDIT_S3_ACCESS_KEY_ID")]
+    s3_access_key_id: Option<String>,
+
+    #[arg(long, env = "TIPS_AUDIT_S3_SECRET_ACCESS_KEY")]
+    s3_secret_access_key: Option<String>,
+
+    #[arg(long, env = "TIPS_AUDIT_METRICS_ADDR", default_value = "0.0.0.0:9002")]
+    metrics_addr: SocketAddr,
+
+    #[arg(long, env = "TIPS_AUDIT_WORKER_POOL_SIZE", default_value = "80")]
+    worker_pool_size: usize,
+
+    #[arg(long, env = "TIPS_AUDIT_CHANNEL_BUFFER_SIZE", default_value = "500")]
+    channel_buffer_size: usize,
+
+    #[arg(long, env = "TIPS_AUDIT_NOOP_ARCHIVE", default_value = "false")]
+    noop_archive: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+
+    init_logger_with_format(&args.log_level, args.log_format);
+
+    init_prometheus_exporter(args.metrics_addr).expect("Failed to install Prometheus exporter");
+
+    info!(
+        kafka_properties_file = %args.kafka_properties_file,
+        kafka_topic = %args.kafka_topic,
+        s3_bucket = %args.s3_bucket,
+        metrics_addr = %args.metrics_addr,
+        "Starting audit archiver"
+    );
+
+    let consumer = create_kafka_consumer(&args.kafka_properties_file)?;
+    consumer.subscribe(&[&args.kafka_topic])?;
+
+    let reader = KafkaAuditLogReader::new(consumer, args.kafka_topic.clone())?;
+
+    let s3_client = create_s3_client(&args).await?;
+    let s3_bucket = args.s3_bucket.clone();
+    let writer = S3EventReaderWriter::new(s3_client, s3_bucket);
+
+    let mut archiver = KafkaAuditArchiver::new(
+        reader,
+        writer,
+        args.worker_pool_size,
+        args.channel_buffer_size,
+        args.noop_archive,
+    );
+
+    info!("Audit archiver initialized, starting main loop");
+
+    archiver.run().await
+}
+
+async fn create_s3_client(args: &Args) -> Result<S3Client> {
+    match args.s3_config_type {
+        S3ConfigType::Manual => {
+            let region = args.s3_region.clone();
+            let mut config_builder =
+                aws_config::defaults(BehaviorVersion::latest()).region(Region::new(region));
+
+            if let Some(endpoint) = &args.s3_endpoint {
+                config_builder = config_builder.endpoint_url(endpoint);
+            }
+
+            if let (Some(access_key), Some(secret_key)) =
+                (&args.s3_access_key_id, &args.s3_secret_access_key)
+            {
+                let credentials = Credentials::new(access_key, secret_key, None, None, "manual");
+                config_builder = config_builder.credentials_provider(credentials);
+            }
+
+            let config = config_builder.load().await;
+            let s3_config_builder = S3ConfigBuilder::from(&config).force_path_style(true);
+
+            info!(message = "manually configuring s3 client");
+            Ok(S3Client::from_conf(s3_config_builder.build()))
+        }
+        S3ConfigType::Aws => {
+            info!(message = "using aws s3 client");
+            let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+            Ok(S3Client::new(&config))
+        }
+    }
+}

--- a/bin/ingress-rpc/Cargo.toml
+++ b/bin/ingress-rpc/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "ingress-rpc-bin"
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "ingress-rpc"
+path = "src/main.rs"
+
+
+[dependencies]
+utils.workspace = true
+base-bundles.workspace = true
+audit.workspace = true
+ingress-rpc.workspace = true
+clap.workspace = true
+tokio.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+dotenvy.workspace = true
+rdkafka.workspace = true
+jsonrpsee.workspace = true
+op-alloy-network.workspace = true
+alloy-provider.workspace = true

--- a/bin/ingress-rpc/src/main.rs
+++ b/bin/ingress-rpc/src/main.rs
@@ -1,0 +1,109 @@
+use alloy_provider::ProviderBuilder;
+use audit::{BundleEvent, KafkaBundleEventPublisher, connect_audit_to_publisher};
+use base_bundles::{AcceptedBundle, MeterBundleResponse};
+use clap::Parser;
+use ingress_rpc::{
+    Config, connect_ingress_to_builder,
+    health::bind_health_server,
+    queue::KafkaMessageQueue,
+    service::{IngressApiServer, IngressService, Providers},
+};
+use jsonrpsee::server::Server;
+use op_alloy_network::Optimism;
+use rdkafka::{ClientConfig, producer::FutureProducer};
+use tokio::sync::{broadcast, mpsc};
+use tracing::info;
+use utils::{
+    kafka::load_kafka_config_from_file, logger::init_logger_with_format,
+    metrics::init_prometheus_exporter,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenvy::dotenv().ok();
+
+    let config = Config::parse();
+    let cfg = config.clone();
+
+    init_logger_with_format(&config.log_level, config.log_format);
+
+    init_prometheus_exporter(config.metrics_addr).expect("Failed to install Prometheus exporter");
+
+    info!(
+        message = "Starting ingress service",
+        address = %config.address,
+        port = config.port,
+        mempool_url = %config.mempool_url,
+        simulation_rpc = %config.simulation_rpc,
+        metrics_address = %config.metrics_addr,
+        health_check_address = %config.health_check_addr,
+    );
+
+    let providers = Providers {
+        mempool: ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .network::<Optimism>()
+            .connect_http(config.mempool_url),
+        simulation: ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .network::<Optimism>()
+            .connect_http(config.simulation_rpc),
+        raw_tx_forward: config.raw_tx_forward_rpc.clone().map(|url| {
+            ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .network::<Optimism>()
+                .connect_http(url)
+        }),
+    };
+
+    let ingress_client_config =
+        ClientConfig::from_iter(load_kafka_config_from_file(&config.ingress_kafka_properties)?);
+
+    let queue_producer: FutureProducer = ingress_client_config.create()?;
+
+    let queue = KafkaMessageQueue::new(queue_producer);
+
+    let audit_client_config =
+        ClientConfig::from_iter(load_kafka_config_from_file(&config.audit_kafka_properties)?);
+
+    let audit_producer: FutureProducer = audit_client_config.create()?;
+
+    let audit_publisher = KafkaBundleEventPublisher::new(audit_producer, config.audit_topic);
+    let (audit_tx, audit_rx) = mpsc::unbounded_channel::<BundleEvent>();
+    connect_audit_to_publisher(audit_rx, audit_publisher);
+
+    let (builder_tx, _) =
+        broadcast::channel::<MeterBundleResponse>(config.max_buffered_meter_bundle_responses);
+    let (builder_backrun_tx, _) =
+        broadcast::channel::<AcceptedBundle>(config.max_buffered_backrun_bundles);
+    config.builder_rpcs.iter().for_each(|builder_rpc| {
+        let metering_rx = builder_tx.subscribe();
+        let backrun_rx = builder_backrun_tx.subscribe();
+        connect_ingress_to_builder(metering_rx, backrun_rx, builder_rpc.clone());
+    });
+
+    let health_check_addr = config.health_check_addr;
+    let (bound_health_addr, health_handle) = bind_health_server(health_check_addr).await?;
+    info!(
+        message = "Health check server started",
+        address = %bound_health_addr
+    );
+
+    let service =
+        IngressService::new(providers, queue, audit_tx, builder_tx, builder_backrun_tx, cfg);
+    let bind_addr = format!("{}:{}", config.address, config.port);
+
+    let server = Server::builder().build(&bind_addr).await?;
+    let addr = server.local_addr()?;
+    let handle = server.start(service.into_rpc());
+
+    info!(
+        message = "Ingress RPC server started",
+        address = %addr
+    );
+
+    handle.stopped().await;
+    health_handle.abort();
+
+    Ok(())
+}

--- a/crates/audit/Cargo.toml
+++ b/crates/audit/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "audit"
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+bytes.workspace = true
+metrics.workspace = true
+async-trait.workspace = true
+metrics-derive.workspace = true
+base-bundles.workspace = true
+utils = { workspace = true }
+serde = { workspace = true, features = ["std", "derive"] }
+tokio = { workspace = true, features = ["full"] }
+uuid = { workspace = true, features = ["v5", "serde"] }
+tracing = { workspace = true, features = ["std"] }
+anyhow = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+rdkafka = { workspace = true, features = ["tokio", "libz", "zstd", "ssl-vendored"] }
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-provider = { workspace = true }
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
+futures = { workspace = true }
+alloy-signer-local = { workspace = true }
+op-alloy-consensus = { workspace = true }
+op-alloy-rpc-types = { workspace = true }
+
+[dev-dependencies]
+audit = { workspace = true }
+testcontainers = { workspace = true, features = ["blocking"] }
+testcontainers-modules = { workspace = true, features = ["postgres", "kafka", "minio"] }
+aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }

--- a/crates/audit/src/archiver.rs
+++ b/crates/audit/src/archiver.rs
@@ -1,0 +1,156 @@
+use std::{
+    fmt,
+    marker::PhantomData,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::Result;
+use tokio::{
+    sync::{Mutex, mpsc},
+    time::sleep,
+};
+use tracing::{error, info};
+
+use crate::{
+    metrics::Metrics,
+    reader::{Event, EventReader},
+    storage::EventWriter,
+};
+
+/// Archives audit events from Kafka to S3 storage.
+pub struct KafkaAuditArchiver<R, W>
+where
+    R: EventReader,
+    W: EventWriter + Clone + Send + 'static,
+{
+    reader: R,
+    event_tx: mpsc::Sender<Event>,
+    metrics: Metrics,
+    _phantom: PhantomData<W>,
+}
+
+impl<R, W> fmt::Debug for KafkaAuditArchiver<R, W>
+where
+    R: EventReader,
+    W: EventWriter + Clone + Send + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KafkaAuditArchiver").finish_non_exhaustive()
+    }
+}
+
+impl<R, W> KafkaAuditArchiver<R, W>
+where
+    R: EventReader,
+    W: EventWriter + Clone + Send + 'static,
+{
+    /// Creates a new archiver with the given reader and writer.
+    pub fn new(
+        reader: R,
+        writer: W,
+        worker_pool_size: usize,
+        channel_buffer_size: usize,
+        noop_archive: bool,
+    ) -> Self {
+        let (event_tx, event_rx) = mpsc::channel(channel_buffer_size);
+        let metrics = Metrics::default();
+
+        Self::spawn_workers(writer, event_rx, metrics.clone(), worker_pool_size, noop_archive);
+
+        Self { reader, event_tx, metrics, _phantom: PhantomData }
+    }
+
+    fn spawn_workers(
+        writer: W,
+        event_rx: mpsc::Receiver<Event>,
+        metrics: Metrics,
+        worker_pool_size: usize,
+        noop_archive: bool,
+    ) {
+        let event_rx = Arc::new(Mutex::new(event_rx));
+
+        for worker_id in 0..worker_pool_size {
+            let writer = writer.clone();
+            let metrics = metrics.clone();
+            let event_rx = Arc::clone(&event_rx);
+
+            tokio::spawn(async move {
+                loop {
+                    let event = {
+                        let mut rx = event_rx.lock().await;
+                        rx.recv().await
+                    };
+
+                    match event {
+                        Some(event) => {
+                            let archive_start = Instant::now();
+                            // tmp: only use this to clear kafka consumer offset
+                            // TODO: use debug! later
+                            if noop_archive {
+                                info!(
+                                    worker_id,
+                                    bundle_id = %event.event.bundle_id(),
+                                    tx_ids = ?event.event.transaction_ids(),
+                                    timestamp = event.timestamp,
+                                    "Noop archive - skipping event"
+                                );
+                                metrics.events_processed.increment(1);
+                                metrics.in_flight_archive_tasks.decrement(1.0);
+                                continue;
+                            }
+                            if let Err(e) = writer.archive_event(event).await {
+                                error!(worker_id, error = %e, "Failed to write event");
+                            } else {
+                                metrics
+                                    .archive_event_duration
+                                    .record(archive_start.elapsed().as_secs_f64());
+                                metrics.events_processed.increment(1);
+                            }
+                            metrics.in_flight_archive_tasks.decrement(1.0);
+                        }
+                        None => {
+                            info!(worker_id, "Worker stopped - channel closed");
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    /// Runs the archiver loop, reading events and writing them to storage.
+    pub async fn run(&mut self) -> Result<()> {
+        loop {
+            let read_start = Instant::now();
+            match self.reader.read_event().await {
+                Ok(event) => {
+                    self.metrics.kafka_read_duration.record(read_start.elapsed().as_secs_f64());
+
+                    let now_ms = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as i64;
+                    let event_age_ms = now_ms.saturating_sub(event.timestamp);
+                    self.metrics.event_age.record(event_age_ms as f64);
+
+                    self.metrics.in_flight_archive_tasks.increment(1.0);
+                    if let Err(e) = self.event_tx.send(event).await {
+                        error!(error = %e, "Failed to send event to worker pool");
+                        self.metrics.in_flight_archive_tasks.decrement(1.0);
+                    }
+
+                    let commit_start = Instant::now();
+                    if let Err(e) = self.reader.commit().await {
+                        error!(error = %e, "Failed to commit message");
+                    }
+                    self.metrics.kafka_commit_duration.record(commit_start.elapsed().as_secs_f64());
+                }
+                Err(e) => {
+                    error!(error = %e, "Error reading events");
+                    sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+}

--- a/crates/audit/src/lib.rs
+++ b/crates/audit/src/lib.rs
@@ -1,0 +1,76 @@
+//! Audit library for tracking and archiving bundle and user operation events.
+//!
+//! This crate provides functionality for publishing events to Kafka,
+//! archiving them to S3, and reading event history.
+
+#![doc(issue_tracker_base_url = "https://github.com/base/tips/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod archiver;
+pub use archiver::KafkaAuditArchiver;
+
+mod metrics;
+pub use metrics::Metrics;
+
+mod publisher;
+pub use publisher::{
+    BundleEventPublisher, KafkaBundleEventPublisher, KafkaUserOpEventPublisher,
+    LoggingBundleEventPublisher, LoggingUserOpEventPublisher, UserOpEventPublisher,
+};
+
+mod reader;
+pub use reader::{
+    Event, EventReader, KafkaAuditLogReader, KafkaUserOpAuditLogReader, UserOpEventReader,
+    UserOpEventWrapper, assign_topic_partition, create_kafka_consumer,
+};
+
+mod storage;
+pub use storage::{
+    BundleEventS3Reader, BundleHistory, BundleHistoryEvent, EventWriter, S3EventReaderWriter,
+    S3Key, TransactionMetadata, UserOpEventS3Reader, UserOpEventWriter, UserOpHistory,
+    UserOpHistoryEvent,
+};
+
+pub mod test_utils;
+
+use tokio::sync::mpsc;
+use tracing::error;
+
+mod types;
+pub use types::{
+    BundleEvent, BundleId, DropReason, Transaction, TransactionId, UserOpDropReason, UserOpEvent,
+    UserOpHash,
+};
+
+/// Connects a bundle event receiver to a publisher, spawning a task to forward events.
+pub fn connect_audit_to_publisher<P>(event_rx: mpsc::UnboundedReceiver<BundleEvent>, publisher: P)
+where
+    P: BundleEventPublisher + 'static,
+{
+    tokio::spawn(async move {
+        let mut event_rx = event_rx;
+        while let Some(event) = event_rx.recv().await {
+            if let Err(e) = publisher.publish(event).await {
+                error!(error = %e, "failed to publish bundle event");
+            }
+        }
+    });
+}
+
+/// Connects a user operation event receiver to a publisher, spawning a task to forward events.
+pub fn connect_userop_audit_to_publisher<P>(
+    event_rx: mpsc::UnboundedReceiver<UserOpEvent>,
+    publisher: P,
+) where
+    P: UserOpEventPublisher + 'static,
+{
+    tokio::spawn(async move {
+        let mut event_rx = event_rx;
+        while let Some(event) = event_rx.recv().await {
+            if let Err(e) = publisher.publish(event).await {
+                error!(error = %e, "Failed to publish user op event");
+            }
+        }
+    });
+}

--- a/crates/audit/src/metrics.rs
+++ b/crates/audit/src/metrics.rs
@@ -1,0 +1,55 @@
+use metrics::{Counter, Gauge, Histogram};
+use metrics_derive::Metrics;
+
+/// Metrics for audit operations including Kafka reads, S3 writes, and event processing.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "tips_audit")]
+pub struct Metrics {
+    /// Duration of `archive_event` operations.
+    #[metric(describe = "Duration of archive_event")]
+    pub archive_event_duration: Histogram,
+
+    /// Age of event when processed (now - event timestamp).
+    #[metric(describe = "Age of event when processed (now - event timestamp)")]
+    pub event_age: Histogram,
+
+    /// Duration of Kafka `read_event` operations.
+    #[metric(describe = "Duration of Kafka read_event")]
+    pub kafka_read_duration: Histogram,
+
+    /// Duration of Kafka commit operations.
+    #[metric(describe = "Duration of Kafka commit")]
+    pub kafka_commit_duration: Histogram,
+
+    /// Duration of `update_bundle_history` operations.
+    #[metric(describe = "Duration of update_bundle_history")]
+    pub update_bundle_history_duration: Histogram,
+
+    /// Duration of updating all transaction indexes.
+    #[metric(describe = "Duration of update all transaction indexes")]
+    pub update_tx_indexes_duration: Histogram,
+
+    /// Duration of S3 `get_object` operations.
+    #[metric(describe = "Duration of S3 get_object")]
+    pub s3_get_duration: Histogram,
+
+    /// Duration of S3 `put_object` operations.
+    #[metric(describe = "Duration of S3 put_object")]
+    pub s3_put_duration: Histogram,
+
+    /// Total events processed.
+    #[metric(describe = "Total events processed")]
+    pub events_processed: Counter,
+
+    /// Total S3 writes skipped due to deduplication.
+    #[metric(describe = "Total S3 writes skipped due to dedup")]
+    pub s3_writes_skipped: Counter,
+
+    /// Number of in-flight archive tasks.
+    #[metric(describe = "Number of in-flight archive tasks")]
+    pub in_flight_archive_tasks: Gauge,
+
+    /// Number of failed archive tasks.
+    #[metric(describe = "Number of failed archive tasks")]
+    pub failed_archive_tasks: Counter,
+}

--- a/crates/audit/src/publisher.rs
+++ b/crates/audit/src/publisher.rs
@@ -1,0 +1,228 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use tracing::{debug, error, info};
+
+use crate::types::{BundleEvent, UserOpEvent};
+
+/// Trait for publishing bundle events.
+#[async_trait]
+pub trait BundleEventPublisher: Send + Sync {
+    /// Publishes a single bundle event.
+    async fn publish(&self, event: BundleEvent) -> Result<()>;
+
+    /// Publishes multiple bundle events.
+    async fn publish_all(&self, events: Vec<BundleEvent>) -> Result<()>;
+}
+
+/// Publishes bundle events to Kafka.
+#[derive(Clone)]
+pub struct KafkaBundleEventPublisher {
+    producer: FutureProducer,
+    topic: String,
+}
+
+impl std::fmt::Debug for KafkaBundleEventPublisher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KafkaBundleEventPublisher")
+            .field("topic", &self.topic)
+            .finish_non_exhaustive()
+    }
+}
+
+impl KafkaBundleEventPublisher {
+    /// Creates a new Kafka bundle event publisher.
+    pub const fn new(producer: FutureProducer, topic: String) -> Self {
+        Self { producer, topic }
+    }
+
+    async fn send_event(&self, event: &BundleEvent) -> Result<()> {
+        let bundle_id = event.bundle_id();
+        let key = event.generate_event_key();
+        let payload = serde_json::to_vec(event)?;
+
+        let record = FutureRecord::to(&self.topic).key(&key).payload(&payload);
+
+        match self.producer.send(record, tokio::time::Duration::from_secs(5)).await {
+            Ok(_) => {
+                debug!(
+                    bundle_id = %bundle_id,
+                    topic = %self.topic,
+                    payload_size = payload.len(),
+                    "successfully published event"
+                );
+                Ok(())
+            }
+            Err((err, _)) => {
+                error!(
+                    bundle_id = %bundle_id,
+                    topic = %self.topic,
+                    error = %err,
+                    "failed to publish event"
+                );
+                Err(anyhow::anyhow!("Failed to publish event: {err}"))
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl BundleEventPublisher for KafkaBundleEventPublisher {
+    async fn publish(&self, event: BundleEvent) -> Result<()> {
+        self.send_event(&event).await
+    }
+
+    async fn publish_all(&self, events: Vec<BundleEvent>) -> Result<()> {
+        for event in events {
+            self.send_event(&event).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Publishes bundle events to logs (for testing/debugging).
+#[derive(Clone, Debug)]
+pub struct LoggingBundleEventPublisher;
+
+impl LoggingBundleEventPublisher {
+    /// Creates a new logging bundle event publisher.
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LoggingBundleEventPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl BundleEventPublisher for LoggingBundleEventPublisher {
+    async fn publish(&self, event: BundleEvent) -> Result<()> {
+        info!(
+            bundle_id = %event.bundle_id(),
+            event = ?event,
+            "Received bundle event"
+        );
+        Ok(())
+    }
+
+    async fn publish_all(&self, events: Vec<BundleEvent>) -> Result<()> {
+        for event in events {
+            self.publish(event).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Trait for publishing user operation events.
+#[async_trait]
+pub trait UserOpEventPublisher: Send + Sync {
+    /// Publishes a single user operation event.
+    async fn publish(&self, event: UserOpEvent) -> Result<()>;
+
+    /// Publishes multiple user operation events.
+    async fn publish_all(&self, events: Vec<UserOpEvent>) -> Result<()>;
+}
+
+/// Publishes user operation events to Kafka.
+#[derive(Clone)]
+pub struct KafkaUserOpEventPublisher {
+    producer: FutureProducer,
+    topic: String,
+}
+
+impl std::fmt::Debug for KafkaUserOpEventPublisher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KafkaUserOpEventPublisher")
+            .field("topic", &self.topic)
+            .finish_non_exhaustive()
+    }
+}
+
+impl KafkaUserOpEventPublisher {
+    /// Creates a new Kafka user operation event publisher.
+    pub const fn new(producer: FutureProducer, topic: String) -> Self {
+        Self { producer, topic }
+    }
+
+    async fn send_event(&self, event: &UserOpEvent) -> Result<()> {
+        let user_op_hash = event.user_op_hash();
+        let key = event.generate_event_key();
+        let payload = serde_json::to_vec(event)?;
+
+        let record = FutureRecord::to(&self.topic).key(&key).payload(&payload);
+
+        match self.producer.send(record, tokio::time::Duration::from_secs(5)).await {
+            Ok(_) => {
+                debug!(
+                    user_op_hash = %user_op_hash,
+                    topic = %self.topic,
+                    payload_size = payload.len(),
+                    "Successfully published user op event"
+                );
+                Ok(())
+            }
+            Err((err, _)) => {
+                error!(
+                    user_op_hash = %user_op_hash,
+                    topic = %self.topic,
+                    error = %err,
+                    "Failed to publish user op event"
+                );
+                Err(anyhow::anyhow!("Failed to publish user op event: {err}"))
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl UserOpEventPublisher for KafkaUserOpEventPublisher {
+    async fn publish(&self, event: UserOpEvent) -> Result<()> {
+        self.send_event(&event).await
+    }
+
+    async fn publish_all(&self, events: Vec<UserOpEvent>) -> Result<()> {
+        for event in events {
+            self.send_event(&event).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Publishes user operation events to logs (for testing/debugging).
+#[derive(Clone, Debug)]
+pub struct LoggingUserOpEventPublisher;
+
+impl LoggingUserOpEventPublisher {
+    /// Creates a new logging user operation event publisher.
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LoggingUserOpEventPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl UserOpEventPublisher for LoggingUserOpEventPublisher {
+    async fn publish(&self, event: UserOpEvent) -> Result<()> {
+        info!(
+            user_op_hash = %event.user_op_hash(),
+            event = ?event,
+            "Received user op event"
+        );
+        Ok(())
+    }
+
+    async fn publish_all(&self, events: Vec<UserOpEvent>) -> Result<()> {
+        for event in events {
+            self.publish(event).await?;
+        }
+        Ok(())
+    }
+}

--- a/crates/audit/src/reader.rs
+++ b/crates/audit/src/reader.rs
@@ -1,0 +1,246 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use rdkafka::{
+    Timestamp, TopicPartitionList,
+    config::ClientConfig,
+    consumer::{Consumer, StreamConsumer},
+    message::Message,
+};
+use tokio::time::sleep;
+use tracing::{debug, error, info};
+use utils::kafka::load_kafka_config_from_file;
+
+use crate::types::{BundleEvent, UserOpEvent};
+
+/// Creates a Kafka consumer from a properties file.
+pub fn create_kafka_consumer(kafka_properties_file: &str) -> Result<StreamConsumer> {
+    let client_config: ClientConfig =
+        ClientConfig::from_iter(load_kafka_config_from_file(kafka_properties_file)?);
+    let consumer: StreamConsumer = client_config.create()?;
+    Ok(consumer)
+}
+
+/// Assigns a topic partition to a consumer.
+pub fn assign_topic_partition(consumer: &StreamConsumer, topic: &str) -> Result<()> {
+    let mut tpl = TopicPartitionList::new();
+    tpl.add_partition(topic, 0);
+    consumer.assign(&tpl)?;
+    Ok(())
+}
+
+/// A bundle event with metadata from Kafka.
+#[derive(Debug, Clone)]
+pub struct Event {
+    /// The event key.
+    pub key: String,
+    /// The bundle event.
+    pub event: BundleEvent,
+    /// The event timestamp in milliseconds.
+    pub timestamp: i64,
+}
+
+/// Trait for reading bundle events.
+#[async_trait]
+pub trait EventReader {
+    /// Reads the next event.
+    async fn read_event(&mut self) -> Result<Event>;
+    /// Commits the last read message.
+    async fn commit(&mut self) -> Result<()>;
+}
+
+/// Reads bundle audit events from Kafka.
+pub struct KafkaAuditLogReader {
+    consumer: StreamConsumer,
+    topic: String,
+    last_message_offset: Option<i64>,
+    last_message_partition: Option<i32>,
+}
+
+impl std::fmt::Debug for KafkaAuditLogReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KafkaAuditLogReader")
+            .field("topic", &self.topic)
+            .field("last_message_offset", &self.last_message_offset)
+            .field("last_message_partition", &self.last_message_partition)
+            .finish_non_exhaustive()
+    }
+}
+
+impl KafkaAuditLogReader {
+    /// Creates a new Kafka audit log reader.
+    pub fn new(consumer: StreamConsumer, topic: String) -> Result<Self> {
+        consumer.subscribe(&[&topic])?;
+        Ok(Self { consumer, topic, last_message_offset: None, last_message_partition: None })
+    }
+}
+
+#[async_trait]
+impl EventReader for KafkaAuditLogReader {
+    async fn read_event(&mut self) -> Result<Event> {
+        match self.consumer.recv().await {
+            Ok(message) => {
+                let payload =
+                    message.payload().ok_or_else(|| anyhow::anyhow!("Message has no payload"))?;
+
+                // Extract Kafka timestamp, use current time as fallback
+                let timestamp = match message.timestamp() {
+                    Timestamp::CreateTime(millis) | Timestamp::LogAppendTime(millis) => millis,
+                    Timestamp::NotAvailable => {
+                        SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis()
+                            as i64
+                    }
+                };
+
+                let event: BundleEvent = serde_json::from_slice(payload)?;
+
+                info!(
+                    bundle_id = %event.bundle_id(),
+                    tx_ids = ?event.transaction_ids(),
+                    timestamp = timestamp,
+                    offset = message.offset(),
+                    partition = message.partition(),
+                    "Received event with timestamp"
+                );
+
+                self.last_message_offset = Some(message.offset());
+                self.last_message_partition = Some(message.partition());
+
+                let key = message
+                    .key()
+                    .map(|k| String::from_utf8_lossy(k).to_string())
+                    .ok_or_else(|| anyhow::anyhow!("Message missing required key"))?;
+
+                let event_result = Event { key, event, timestamp };
+
+                Ok(event_result)
+            }
+            Err(e) => {
+                error!(error = %e, "Error receiving message from Kafka");
+                sleep(Duration::from_secs(1)).await;
+                Err(e.into())
+            }
+        }
+    }
+
+    async fn commit(&mut self) -> Result<()> {
+        if let (Some(offset), Some(partition)) =
+            (self.last_message_offset, self.last_message_partition)
+        {
+            let mut tpl = TopicPartitionList::new();
+            tpl.add_partition_offset(&self.topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+            self.consumer.commit(&tpl, rdkafka::consumer::CommitMode::Async)?;
+        }
+        Ok(())
+    }
+}
+
+impl KafkaAuditLogReader {
+    /// Returns the topic this reader is subscribed to.
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
+}
+
+/// A user operation event with metadata from Kafka.
+#[derive(Debug, Clone)]
+pub struct UserOpEventWrapper {
+    /// The event key.
+    pub key: String,
+    /// The user operation event.
+    pub event: UserOpEvent,
+    /// The event timestamp in milliseconds.
+    pub timestamp: i64,
+}
+
+/// Trait for reading user operation events.
+#[async_trait]
+pub trait UserOpEventReader {
+    /// Reads the next user operation event.
+    async fn read_event(&mut self) -> Result<UserOpEventWrapper>;
+    /// Commits the last read message.
+    async fn commit(&mut self) -> Result<()>;
+}
+
+/// Reads user operation audit events from Kafka.
+pub struct KafkaUserOpAuditLogReader {
+    consumer: StreamConsumer,
+    topic: String,
+    last_message_offset: Option<i64>,
+    last_message_partition: Option<i32>,
+}
+
+impl std::fmt::Debug for KafkaUserOpAuditLogReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KafkaUserOpAuditLogReader")
+            .field("topic", &self.topic)
+            .field("last_message_offset", &self.last_message_offset)
+            .field("last_message_partition", &self.last_message_partition)
+            .finish_non_exhaustive()
+    }
+}
+
+impl KafkaUserOpAuditLogReader {
+    /// Creates a new Kafka user operation audit log reader.
+    pub fn new(consumer: StreamConsumer, topic: String) -> Result<Self> {
+        consumer.subscribe(&[&topic])?;
+        Ok(Self { consumer, topic, last_message_offset: None, last_message_partition: None })
+    }
+}
+
+#[async_trait]
+impl UserOpEventReader for KafkaUserOpAuditLogReader {
+    async fn read_event(&mut self) -> Result<UserOpEventWrapper> {
+        match self.consumer.recv().await {
+            Ok(message) => {
+                let payload =
+                    message.payload().ok_or_else(|| anyhow::anyhow!("Message has no payload"))?;
+
+                let timestamp = match message.timestamp() {
+                    Timestamp::CreateTime(millis) | Timestamp::LogAppendTime(millis) => millis,
+                    Timestamp::NotAvailable => {
+                        SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis()
+                            as i64
+                    }
+                };
+
+                let event: UserOpEvent = serde_json::from_slice(payload)?;
+
+                debug!(
+                    user_op_hash = %event.user_op_hash(),
+                    timestamp = timestamp,
+                    offset = message.offset(),
+                    partition = message.partition(),
+                    "Received UserOp event"
+                );
+
+                self.last_message_offset = Some(message.offset());
+                self.last_message_partition = Some(message.partition());
+
+                let key = message
+                    .key()
+                    .map(|k| String::from_utf8_lossy(k).to_string())
+                    .ok_or_else(|| anyhow::anyhow!("Message missing required key"))?;
+
+                Ok(UserOpEventWrapper { key, event, timestamp })
+            }
+            Err(e) => {
+                error!(error = %e, "Error receiving UserOp message from Kafka");
+                sleep(Duration::from_secs(1)).await;
+                Err(e.into())
+            }
+        }
+    }
+
+    async fn commit(&mut self) -> Result<()> {
+        if let (Some(offset), Some(partition)) =
+            (self.last_message_offset, self.last_message_partition)
+        {
+            let mut tpl = TopicPartitionList::new();
+            tpl.add_partition_offset(&self.topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+            self.consumer.commit(&tpl, rdkafka::consumer::CommitMode::Async)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/audit/src/storage.rs
+++ b/crates/audit/src/storage.rs
@@ -1,0 +1,925 @@
+use std::{fmt, fmt::Debug, time::Instant};
+
+use alloy_primitives::{Address, TxHash, U256};
+use anyhow::Result;
+use async_trait::async_trait;
+use aws_sdk_s3::{
+    Client as S3Client, error::SdkError, operation::get_object::GetObjectError,
+    primitives::ByteStream,
+};
+use base_bundles::AcceptedBundle;
+use futures::future;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use crate::{
+    metrics::Metrics,
+    reader::Event,
+    types::{
+        BundleEvent, BundleId, DropReason, TransactionId, UserOpDropReason, UserOpEvent, UserOpHash,
+    },
+};
+
+/// S3 key types for storing different event types.
+#[derive(Debug)]
+pub enum S3Key {
+    /// Key for bundle events.
+    Bundle(BundleId),
+    /// Key for transaction lookups by hash.
+    TransactionByHash(TxHash),
+    /// Key for user operation events.
+    UserOp(UserOpHash),
+}
+
+impl fmt::Display for S3Key {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bundle(bundle_id) => write!(f, "bundles/{bundle_id}"),
+            Self::TransactionByHash(hash) => write!(f, "transactions/by_hash/{hash}"),
+            Self::UserOp(user_op_hash) => write!(f, "userops/{user_op_hash}"),
+        }
+    }
+}
+
+/// Metadata for a transaction, tracking which bundles it belongs to.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TransactionMetadata {
+    /// Bundle IDs that contain this transaction.
+    pub bundle_ids: Vec<BundleId>,
+}
+
+/// History event for a bundle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", content = "data")]
+pub enum BundleHistoryEvent {
+    /// Bundle was received.
+    Received {
+        /// Event key.
+        key: String,
+        /// Event timestamp.
+        timestamp: i64,
+        /// The accepted bundle.
+        bundle: Box<AcceptedBundle>,
+    },
+    /// Bundle was cancelled.
+    Cancelled {
+        /// Event key.
+        key: String,
+        /// Event timestamp.
+        timestamp: i64,
+    },
+    /// Bundle was included by a builder.
+    BuilderIncluded {
+        /// Event key.
+        key: String,
+        /// Event timestamp.
+        timestamp: i64,
+        /// Builder identifier.
+        builder: String,
+        /// Block number.
+        block_number: u64,
+        /// Flashblock index.
+        flashblock_index: u64,
+    },
+    /// Bundle was included in a block.
+    BlockIncluded {
+        /// Event key.
+        key: String,
+        /// Event timestamp.
+        timestamp: i64,
+        /// Block number.
+        block_number: u64,
+        /// Block hash.
+        block_hash: TxHash,
+    },
+    /// Bundle was dropped.
+    Dropped {
+        /// Event key.
+        key: String,
+        /// Event timestamp.
+        timestamp: i64,
+        /// Drop reason.
+        reason: DropReason,
+    },
+}
+
+impl BundleHistoryEvent {
+    /// Returns the event key.
+    pub fn key(&self) -> &str {
+        match self {
+            Self::Received { key, .. }
+            | Self::Cancelled { key, .. }
+            | Self::BuilderIncluded { key, .. }
+            | Self::BlockIncluded { key, .. }
+            | Self::Dropped { key, .. } => key,
+        }
+    }
+}
+
+/// History of events for a bundle.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BundleHistory {
+    /// List of history events.
+    pub history: Vec<BundleHistoryEvent>,
+}
+
+/// History event for a user operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", content = "data")]
+pub enum UserOpHistoryEvent {
+    /// User operation was added to the mempool.
+    AddedToMempool {
+        /// Event key.
+        key: String,
+        /// Event timestamp.
+        timestamp: i64,
+        /// Sender address.
+        sender: Address,
+        /// Entry point address.
+        entry_point: Address,
+        /// Nonce.
+        nonce: U256,
+    },
+    /// User operation was dropped.
+    Dropped {
+        /// Event key.
+        key: String,
+        /// Event timestamp.
+        timestamp: i64,
+        /// Drop reason.
+        reason: UserOpDropReason,
+    },
+    /// User operation was included in a block.
+    Included {
+        /// Event key.
+        key: String,
+        /// Event timestamp.
+        timestamp: i64,
+        /// Block number.
+        block_number: u64,
+        /// Transaction hash.
+        tx_hash: TxHash,
+    },
+}
+
+impl UserOpHistoryEvent {
+    /// Returns the event key.
+    pub fn key(&self) -> &str {
+        match self {
+            Self::AddedToMempool { key, .. }
+            | Self::Dropped { key, .. }
+            | Self::Included { key, .. } => key,
+        }
+    }
+}
+
+/// History of events for a user operation.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserOpHistory {
+    /// List of history events.
+    pub history: Vec<UserOpHistoryEvent>,
+}
+
+pub(crate) use crate::reader::UserOpEventWrapper;
+
+fn update_bundle_history_transform(
+    bundle_history: BundleHistory,
+    event: &Event,
+) -> Option<BundleHistory> {
+    let mut history = bundle_history.history;
+    let bundle_id = event.event.bundle_id();
+
+    // Check for deduplication - if event with same key already exists, skip
+    if history.iter().any(|h| h.key() == event.key) {
+        info!(
+            bundle_id = %bundle_id,
+            event_key = %event.key,
+            "Event already exists, skipping due to deduplication"
+        );
+        return None;
+    }
+
+    let history_event = match &event.event {
+        BundleEvent::Received { bundle, .. } => BundleHistoryEvent::Received {
+            key: event.key.clone(),
+            timestamp: event.timestamp,
+            bundle: bundle.clone(),
+        },
+        BundleEvent::Cancelled { .. } => {
+            BundleHistoryEvent::Cancelled { key: event.key.clone(), timestamp: event.timestamp }
+        }
+        BundleEvent::BuilderIncluded { builder, block_number, flashblock_index, .. } => {
+            BundleHistoryEvent::BuilderIncluded {
+                key: event.key.clone(),
+                timestamp: event.timestamp,
+                builder: builder.clone(),
+                block_number: *block_number,
+                flashblock_index: *flashblock_index,
+            }
+        }
+        BundleEvent::BlockIncluded { block_number, block_hash, .. } => {
+            BundleHistoryEvent::BlockIncluded {
+                key: event.key.clone(),
+                timestamp: event.timestamp,
+                block_number: *block_number,
+                block_hash: *block_hash,
+            }
+        }
+        BundleEvent::Dropped { reason, .. } => BundleHistoryEvent::Dropped {
+            key: event.key.clone(),
+            timestamp: event.timestamp,
+            reason: reason.clone(),
+        },
+    };
+
+    history.push(history_event);
+    let bundle_history = BundleHistory { history };
+
+    info!(
+        bundle_id = %bundle_id,
+        event_count = bundle_history.history.len(),
+        "Updated bundle history"
+    );
+
+    Some(bundle_history)
+}
+
+fn update_transaction_metadata_transform(
+    transaction_metadata: TransactionMetadata,
+    bundle_id: BundleId,
+) -> Option<TransactionMetadata> {
+    let mut bundle_ids = transaction_metadata.bundle_ids;
+
+    if bundle_ids.contains(&bundle_id) {
+        return None;
+    }
+
+    bundle_ids.push(bundle_id);
+    Some(TransactionMetadata { bundle_ids })
+}
+
+fn update_userop_history_transform(
+    userop_history: UserOpHistory,
+    event: &UserOpEventWrapper,
+) -> Option<UserOpHistory> {
+    let mut history = userop_history.history;
+    let user_op_hash = event.event.user_op_hash();
+
+    if history.iter().any(|h| h.key() == event.key) {
+        info!(
+            user_op_hash = %user_op_hash,
+            event_key = %event.key,
+            "UserOp event already exists, skipping due to deduplication"
+        );
+        return None;
+    }
+
+    let history_event = match &event.event {
+        UserOpEvent::AddedToMempool { sender, entry_point, nonce, .. } => {
+            UserOpHistoryEvent::AddedToMempool {
+                key: event.key.clone(),
+                timestamp: event.timestamp,
+                sender: *sender,
+                entry_point: *entry_point,
+                nonce: *nonce,
+            }
+        }
+        UserOpEvent::Dropped { reason, .. } => UserOpHistoryEvent::Dropped {
+            key: event.key.clone(),
+            timestamp: event.timestamp,
+            reason: reason.clone(),
+        },
+        UserOpEvent::Included { block_number, tx_hash, .. } => UserOpHistoryEvent::Included {
+            key: event.key.clone(),
+            timestamp: event.timestamp,
+            block_number: *block_number,
+            tx_hash: *tx_hash,
+        },
+    };
+
+    history.push(history_event);
+    let userop_history = UserOpHistory { history };
+
+    info!(
+        user_op_hash = %user_op_hash,
+        event_count = userop_history.history.len(),
+        "Updated user op history"
+    );
+
+    Some(userop_history)
+}
+
+/// Trait for writing bundle events to storage.
+#[async_trait]
+pub trait EventWriter {
+    /// Archives a bundle event.
+    async fn archive_event(&self, event: Event) -> Result<()>;
+}
+
+/// Trait for writing user operation events to storage.
+#[async_trait]
+pub trait UserOpEventWriter {
+    /// Archives a user operation event.
+    async fn archive_userop_event(&self, event: UserOpEventWrapper) -> Result<()>;
+}
+
+/// Trait for reading bundle events from S3.
+#[async_trait]
+pub trait BundleEventS3Reader {
+    /// Gets the bundle history for a given bundle ID.
+    async fn get_bundle_history(&self, bundle_id: BundleId) -> Result<Option<BundleHistory>>;
+    /// Gets transaction metadata for a given transaction hash.
+    async fn get_transaction_metadata(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<Option<TransactionMetadata>>;
+}
+
+/// Trait for reading user operation events from S3.
+#[async_trait]
+pub trait UserOpEventS3Reader {
+    /// Gets the user operation history for a given hash.
+    async fn get_userop_history(&self, user_op_hash: UserOpHash) -> Result<Option<UserOpHistory>>;
+}
+
+/// S3-backed event reader and writer.
+#[derive(Clone, Debug)]
+pub struct S3EventReaderWriter {
+    s3_client: S3Client,
+    bucket: String,
+    metrics: Metrics,
+}
+
+impl S3EventReaderWriter {
+    /// Creates a new S3 event reader/writer.
+    pub fn new(s3_client: S3Client, bucket: String) -> Self {
+        Self { s3_client, bucket, metrics: Metrics::default() }
+    }
+
+    async fn update_bundle_history(&self, event: Event) -> Result<()> {
+        let s3_key = S3Key::Bundle(event.event.bundle_id()).to_string();
+
+        self.idempotent_write::<BundleHistory, _>(&s3_key, |current_history| {
+            update_bundle_history_transform(current_history, &event)
+        })
+        .await
+    }
+
+    async fn update_transaction_by_hash_index(
+        &self,
+        tx_id: &TransactionId,
+        bundle_id: BundleId,
+    ) -> Result<()> {
+        let s3_key = S3Key::TransactionByHash(tx_id.hash);
+        let key = s3_key.to_string();
+
+        self.idempotent_write::<TransactionMetadata, _>(&key, |current_metadata| {
+            update_transaction_metadata_transform(current_metadata, bundle_id)
+        })
+        .await
+    }
+
+    async fn update_userop_history(&self, event: UserOpEventWrapper) -> Result<()> {
+        let s3_key = S3Key::UserOp(event.event.user_op_hash()).to_string();
+
+        self.idempotent_write::<UserOpHistory, _>(&s3_key, |current_history| {
+            update_userop_history_transform(current_history, &event)
+        })
+        .await
+    }
+
+    async fn idempotent_write<T, F>(&self, key: &str, mut transform_fn: F) -> Result<()>
+    where
+        T: for<'de> Deserialize<'de> + Serialize + Clone + Default + Debug,
+        F: FnMut(T) -> Option<T>,
+    {
+        const MAX_RETRIES: usize = 5;
+        const BASE_DELAY_MS: u64 = 100;
+
+        for attempt in 0..MAX_RETRIES {
+            let get_start = Instant::now();
+            let (current_value, etag) = self.get_object_with_etag::<T>(key).await?;
+            self.metrics.s3_get_duration.record(get_start.elapsed().as_secs_f64());
+
+            let value = current_value.unwrap_or_default();
+
+            match transform_fn(value.clone()) {
+                Some(new_value) => {
+                    let content = serde_json::to_string(&new_value)?;
+
+                    let mut put_request = self
+                        .s3_client
+                        .put_object()
+                        .bucket(&self.bucket)
+                        .key(key)
+                        .body(ByteStream::from(content.into_bytes()));
+
+                    if let Some(etag) = etag {
+                        put_request = put_request.if_match(etag);
+                    } else {
+                        put_request = put_request.if_none_match("*");
+                    }
+
+                    let put_start = Instant::now();
+                    match put_request.send().await {
+                        Ok(_) => {
+                            self.metrics.s3_put_duration.record(put_start.elapsed().as_secs_f64());
+                            info!(
+                                s3_key = %key,
+                                attempt = attempt + 1,
+                                "Successfully wrote object with idempotent write"
+                            );
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            self.metrics.s3_put_duration.record(put_start.elapsed().as_secs_f64());
+
+                            if attempt < MAX_RETRIES - 1 {
+                                let delay = BASE_DELAY_MS * 2_u64.pow(attempt as u32);
+                                info!(
+                                    s3_key = %key,
+                                    attempt = attempt + 1,
+                                    delay_ms = delay,
+                                    error = %e,
+                                    "Conflict detected, retrying with backoff"
+                                );
+                                tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+                            } else {
+                                return Err(anyhow::anyhow!(
+                                    "Failed to write after {MAX_RETRIES} attempts: {e}"
+                                ));
+                            }
+                        }
+                    }
+                }
+                None => {
+                    self.metrics.s3_writes_skipped.increment(1);
+                    info!(
+                        s3_key = %key,
+                        "Transform function returned None, no write required"
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!("Exceeded maximum retry attempts"))
+    }
+
+    async fn get_object_with_etag<T>(&self, key: &str) -> Result<(Option<T>, Option<String>)>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        match self.s3_client.get_object().bucket(&self.bucket).key(key).send().await {
+            Ok(response) => {
+                let etag = response.e_tag().map(|s| s.to_string());
+                let body = response.body.collect().await?;
+                let content = String::from_utf8(body.into_bytes().to_vec())?;
+                let value: T = serde_json::from_str(&content)?;
+                Ok((Some(value), etag))
+            }
+            Err(e) => match &e {
+                SdkError::ServiceError(service_err) => match service_err.err() {
+                    GetObjectError::NoSuchKey(_) => Ok((None, None)),
+                    _ => Err(anyhow::anyhow!("Failed to get object: {e}")),
+                },
+                _ => {
+                    let error_string = e.to_string();
+                    if error_string.contains("NoSuchKey")
+                        || error_string.contains("NotFound")
+                        || error_string.contains("404")
+                    {
+                        Ok((None, None))
+                    } else {
+                        Err(anyhow::anyhow!("Failed to get object: {e}"))
+                    }
+                }
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl EventWriter for S3EventReaderWriter {
+    async fn archive_event(&self, event: Event) -> Result<()> {
+        let bundle_id = event.event.bundle_id();
+        let transaction_ids = event.event.transaction_ids();
+
+        let bundle_start = Instant::now();
+        let bundle_future = self.update_bundle_history(event);
+
+        let tx_start = Instant::now();
+        let tx_futures: Vec<_> =
+            transaction_ids
+                .into_iter()
+                .map(|tx_id| async move {
+                    self.update_transaction_by_hash_index(&tx_id, bundle_id).await
+                })
+                .collect();
+
+        // Run the bundle and transaction futures concurrently and wait for them to complete
+        tokio::try_join!(bundle_future, future::try_join_all(tx_futures))?;
+
+        self.metrics.update_bundle_history_duration.record(bundle_start.elapsed().as_secs_f64());
+        self.metrics.update_tx_indexes_duration.record(tx_start.elapsed().as_secs_f64());
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl BundleEventS3Reader for S3EventReaderWriter {
+    async fn get_bundle_history(&self, bundle_id: BundleId) -> Result<Option<BundleHistory>> {
+        let s3_key = S3Key::Bundle(bundle_id).to_string();
+        let (bundle_history, _) = self.get_object_with_etag::<BundleHistory>(&s3_key).await?;
+        Ok(bundle_history)
+    }
+
+    async fn get_transaction_metadata(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<Option<TransactionMetadata>> {
+        let s3_key = S3Key::TransactionByHash(tx_hash).to_string();
+        let (transaction_metadata, _) =
+            self.get_object_with_etag::<TransactionMetadata>(&s3_key).await?;
+        Ok(transaction_metadata)
+    }
+}
+
+#[async_trait]
+impl UserOpEventWriter for S3EventReaderWriter {
+    async fn archive_userop_event(&self, event: UserOpEventWrapper) -> Result<()> {
+        self.update_userop_history(event).await
+    }
+}
+
+#[async_trait]
+impl UserOpEventS3Reader for S3EventReaderWriter {
+    async fn get_userop_history(&self, user_op_hash: UserOpHash) -> Result<Option<UserOpHistory>> {
+        let s3_key = S3Key::UserOp(user_op_hash).to_string();
+        let (userop_history, _) = self.get_object_with_etag::<UserOpHistory>(&s3_key).await?;
+        Ok(userop_history)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, TxHash, U256};
+    use base_bundles::BundleExtensions;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{
+        reader::Event,
+        test_utils::create_bundle_from_txn_data,
+        types::{BundleEvent, DropReason, UserOpDropReason, UserOpEvent},
+    };
+
+    fn create_test_event(key: &str, timestamp: i64, bundle_event: BundleEvent) -> Event {
+        Event { key: key.to_string(), timestamp, event: bundle_event }
+    }
+
+    #[test]
+    fn test_update_bundle_history_transform_adds_new_event() {
+        let bundle_history = BundleHistory { history: vec![] };
+        let bundle = create_bundle_from_txn_data();
+        let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+        let bundle_event = BundleEvent::Received { bundle_id, bundle: Box::new(bundle.clone()) };
+        let event = create_test_event("test-key", 1234567890, bundle_event);
+
+        let result = update_bundle_history_transform(bundle_history, &event);
+
+        assert!(result.is_some());
+        let bundle_history = result.unwrap();
+        assert_eq!(bundle_history.history.len(), 1);
+
+        match &bundle_history.history[0] {
+            BundleHistoryEvent::Received { key, timestamp: ts, bundle: b } => {
+                assert_eq!(key, "test-key");
+                assert_eq!(*ts, 1234567890);
+                assert_eq!(b.block_number, bundle.block_number);
+            }
+            _ => panic!("Expected Created event"),
+        }
+    }
+
+    #[test]
+    fn test_update_bundle_history_transform_skips_duplicate_key() {
+        let existing_event = BundleHistoryEvent::Received {
+            key: "duplicate-key".to_string(),
+            timestamp: 1111111111,
+            bundle: Box::new(create_bundle_from_txn_data()),
+        };
+        let bundle_history = BundleHistory { history: vec![existing_event] };
+
+        let bundle = create_bundle_from_txn_data();
+        let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+        let bundle_event = BundleEvent::Received { bundle_id, bundle: Box::new(bundle) };
+        let event = create_test_event("duplicate-key", 1234567890, bundle_event);
+
+        let result = update_bundle_history_transform(bundle_history, &event);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_update_bundle_history_transform_handles_all_event_types() {
+        let bundle_history = BundleHistory { history: vec![] };
+        let bundle = create_bundle_from_txn_data();
+        let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+
+        let bundle_event = BundleEvent::Received { bundle_id, bundle: Box::new(bundle) };
+        let event = create_test_event("test-key", 1234567890, bundle_event);
+        let result = update_bundle_history_transform(bundle_history.clone(), &event);
+        assert!(result.is_some());
+
+        let bundle_event = BundleEvent::Cancelled { bundle_id };
+        let event = create_test_event("test-key-2", 1234567890, bundle_event);
+        let result = update_bundle_history_transform(bundle_history.clone(), &event);
+        assert!(result.is_some());
+
+        let bundle_event = BundleEvent::BuilderIncluded {
+            bundle_id,
+            builder: "test-builder".to_string(),
+            block_number: 12345,
+            flashblock_index: 1,
+        };
+        let event = create_test_event("test-key-3", 1234567890, bundle_event);
+        let result = update_bundle_history_transform(bundle_history.clone(), &event);
+        assert!(result.is_some());
+
+        let bundle_event = BundleEvent::BlockIncluded {
+            bundle_id,
+            block_number: 12345,
+            block_hash: TxHash::from([1u8; 32]),
+        };
+        let event = create_test_event("test-key-4", 1234567890, bundle_event);
+        let result = update_bundle_history_transform(bundle_history.clone(), &event);
+        assert!(result.is_some());
+
+        let bundle_event = BundleEvent::Dropped { bundle_id, reason: DropReason::TimedOut };
+        let event = create_test_event("test-key-5", 1234567890, bundle_event);
+        let result = update_bundle_history_transform(bundle_history, &event);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_update_transaction_metadata_transform_adds_new_bundle() {
+        let metadata = TransactionMetadata { bundle_ids: vec![] };
+        let bundle = create_bundle_from_txn_data();
+        let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+
+        let result = update_transaction_metadata_transform(metadata, bundle_id);
+
+        assert!(result.is_some());
+        let metadata = result.unwrap();
+        assert_eq!(metadata.bundle_ids.len(), 1);
+        assert_eq!(metadata.bundle_ids[0], bundle_id);
+    }
+
+    #[test]
+    fn test_update_transaction_metadata_transform_skips_existing_bundle() {
+        let bundle = create_bundle_from_txn_data();
+        let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+        let metadata = TransactionMetadata { bundle_ids: vec![bundle_id] };
+
+        let result = update_transaction_metadata_transform(metadata, bundle_id);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_update_transaction_metadata_transform_adds_to_existing_bundles() {
+        // Some different, dummy bundle IDs since create_bundle_from_txn_data() returns the same bundle ID
+        // Even if the same txn is contained across multiple bundles, the bundle ID will be different since the
+        // UUID is based on the bundle hash.
+        let existing_bundle_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let new_bundle_id = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+
+        let metadata = TransactionMetadata { bundle_ids: vec![existing_bundle_id] };
+
+        let result = update_transaction_metadata_transform(metadata, new_bundle_id);
+
+        assert!(result.is_some());
+        let metadata = result.unwrap();
+        assert_eq!(metadata.bundle_ids.len(), 2);
+        assert!(metadata.bundle_ids.contains(&existing_bundle_id));
+        assert!(metadata.bundle_ids.contains(&new_bundle_id));
+    }
+
+    fn create_test_userop_event(
+        key: &str,
+        timestamp: i64,
+        userop_event: UserOpEvent,
+    ) -> UserOpEventWrapper {
+        UserOpEventWrapper { key: key.to_string(), timestamp, event: userop_event }
+    }
+
+    #[test]
+    fn test_s3_key_userop_display() {
+        let hash = B256::from([1u8; 32]);
+        let key = S3Key::UserOp(hash);
+        let key_str = key.to_string();
+        assert!(key_str.starts_with("userops/"));
+        assert!(key_str.contains(&format!("{hash}")));
+    }
+
+    #[test]
+    fn test_update_userop_history_transform_adds_new_event() {
+        let userop_history = UserOpHistory { history: vec![] };
+        let user_op_hash = B256::from([1u8; 32]);
+        let sender = Address::from([2u8; 20]);
+        let entry_point = Address::from([3u8; 20]);
+        let nonce = U256::from(1);
+
+        let userop_event = UserOpEvent::AddedToMempool { user_op_hash, sender, entry_point, nonce };
+        let event = create_test_userop_event("test-key", 1234567890, userop_event);
+
+        let result = update_userop_history_transform(userop_history, &event);
+
+        assert!(result.is_some());
+        let history = result.unwrap();
+        assert_eq!(history.history.len(), 1);
+
+        match &history.history[0] {
+            UserOpHistoryEvent::AddedToMempool {
+                key,
+                timestamp: ts,
+                sender: s,
+                entry_point: ep,
+                nonce: n,
+            } => {
+                assert_eq!(key, "test-key");
+                assert_eq!(*ts, 1234567890);
+                assert_eq!(*s, sender);
+                assert_eq!(*ep, entry_point);
+                assert_eq!(*n, nonce);
+            }
+            _ => panic!("Expected AddedToMempool event"),
+        }
+    }
+
+    #[test]
+    fn test_update_userop_history_transform_skips_duplicate_key() {
+        let user_op_hash = B256::from([1u8; 32]);
+        let sender = Address::from([2u8; 20]);
+        let entry_point = Address::from([3u8; 20]);
+        let nonce = U256::from(1);
+
+        let existing_event = UserOpHistoryEvent::AddedToMempool {
+            key: "duplicate-key".to_string(),
+            timestamp: 1111111111,
+            sender,
+            entry_point,
+            nonce,
+        };
+        let userop_history = UserOpHistory { history: vec![existing_event] };
+
+        let userop_event = UserOpEvent::AddedToMempool { user_op_hash, sender, entry_point, nonce };
+        let event = create_test_userop_event("duplicate-key", 1234567890, userop_event);
+
+        let result = update_userop_history_transform(userop_history, &event);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_update_userop_history_transform_handles_dropped_event() {
+        let userop_history = UserOpHistory { history: vec![] };
+        let user_op_hash = B256::from([1u8; 32]);
+        let reason = UserOpDropReason::Expired;
+
+        let userop_event = UserOpEvent::Dropped { user_op_hash, reason };
+        let event = create_test_userop_event("dropped-key", 1234567890, userop_event);
+
+        let result = update_userop_history_transform(userop_history, &event);
+
+        assert!(result.is_some());
+        let history = result.unwrap();
+        assert_eq!(history.history.len(), 1);
+
+        match &history.history[0] {
+            UserOpHistoryEvent::Dropped { key, timestamp, reason: r } => {
+                assert_eq!(key, "dropped-key");
+                assert_eq!(*timestamp, 1234567890);
+                match r {
+                    UserOpDropReason::Expired => {}
+                    _ => panic!("Expected Expired reason"),
+                }
+            }
+            _ => panic!("Expected Dropped event"),
+        }
+    }
+
+    #[test]
+    fn test_update_userop_history_transform_handles_included_event() {
+        let userop_history = UserOpHistory { history: vec![] };
+        let user_op_hash = B256::from([1u8; 32]);
+        let tx_hash = TxHash::from([4u8; 32]);
+        let block_number = 12345u64;
+
+        let userop_event = UserOpEvent::Included { user_op_hash, block_number, tx_hash };
+        let event = create_test_userop_event("included-key", 1234567890, userop_event);
+
+        let result = update_userop_history_transform(userop_history, &event);
+
+        assert!(result.is_some());
+        let history = result.unwrap();
+        assert_eq!(history.history.len(), 1);
+
+        match &history.history[0] {
+            UserOpHistoryEvent::Included { key, timestamp, block_number: bn, tx_hash: th } => {
+                assert_eq!(key, "included-key");
+                assert_eq!(*timestamp, 1234567890);
+                assert_eq!(*bn, 12345);
+                assert_eq!(*th, tx_hash);
+            }
+            _ => panic!("Expected Included event"),
+        }
+    }
+
+    #[test]
+    fn test_update_userop_history_transform_handles_all_event_types() {
+        let userop_history = UserOpHistory { history: vec![] };
+        let user_op_hash = B256::from([1u8; 32]);
+        let sender = Address::from([2u8; 20]);
+        let entry_point = Address::from([3u8; 20]);
+        let nonce = U256::from(1);
+
+        let userop_event = UserOpEvent::AddedToMempool { user_op_hash, sender, entry_point, nonce };
+        let event = create_test_userop_event("key-1", 1234567890, userop_event);
+        let result = update_userop_history_transform(userop_history.clone(), &event);
+        assert!(result.is_some());
+
+        let userop_event = UserOpEvent::Dropped {
+            user_op_hash,
+            reason: UserOpDropReason::Invalid("test error".to_string()),
+        };
+        let event = create_test_userop_event("key-2", 1234567891, userop_event);
+        let result = update_userop_history_transform(userop_history.clone(), &event);
+        assert!(result.is_some());
+
+        let userop_event = UserOpEvent::Included {
+            user_op_hash,
+            block_number: 12345,
+            tx_hash: TxHash::from([4u8; 32]),
+        };
+        let event = create_test_userop_event("key-3", 1234567892, userop_event);
+        let result = update_userop_history_transform(userop_history, &event);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_userop_history_event_key_accessor() {
+        let sender = Address::from([2u8; 20]);
+        let entry_point = Address::from([3u8; 20]);
+        let nonce = U256::from(1);
+
+        let event1 = UserOpHistoryEvent::AddedToMempool {
+            key: "key-1".to_string(),
+            timestamp: 1234567890,
+            sender,
+            entry_point,
+            nonce,
+        };
+        assert_eq!(event1.key(), "key-1");
+
+        let event2 = UserOpHistoryEvent::Dropped {
+            key: "key-2".to_string(),
+            timestamp: 1234567890,
+            reason: UserOpDropReason::Expired,
+        };
+        assert_eq!(event2.key(), "key-2");
+
+        let event3 = UserOpHistoryEvent::Included {
+            key: "key-3".to_string(),
+            timestamp: 1234567890,
+            block_number: 12345,
+            tx_hash: TxHash::from([4u8; 32]),
+        };
+        assert_eq!(event3.key(), "key-3");
+    }
+
+    #[test]
+    fn test_userop_history_serialization() {
+        let sender = Address::from([2u8; 20]);
+        let entry_point = Address::from([3u8; 20]);
+        let nonce = U256::from(1);
+
+        let history = UserOpHistory {
+            history: vec![UserOpHistoryEvent::AddedToMempool {
+                key: "test-key".to_string(),
+                timestamp: 1234567890,
+                sender,
+                entry_point,
+                nonce,
+            }],
+        };
+
+        let json = serde_json::to_string(&history).unwrap();
+        let deserialized: UserOpHistory = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.history.len(), 1);
+        assert_eq!(deserialized.history[0].key(), "test-key");
+    }
+}

--- a/crates/audit/src/test_utils.rs
+++ b/crates/audit/src/test_utils.rs
@@ -1,0 +1,76 @@
+//! Test utilities for creating bundles and transactions.
+
+use alloy_consensus::SignableTransaction;
+use alloy_primitives::{Address, Bytes, TxHash, U256, b256, bytes};
+use alloy_provider::network::{TxSignerSync, eip2718::Encodable2718};
+use alloy_signer_local::PrivateKeySigner;
+use base_bundles::{AcceptedBundle, Bundle, MeterBundleResponse};
+use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_rpc_types::OpTransactionRequest;
+
+// https://basescan.org/tx/0x4f7ddfc911f5cf85dd15a413f4cbb2a0abe4f1ff275ed13581958c0bcf043c5e
+pub const TXN_DATA: Bytes = bytes!(
+    "0x02f88f8221058304b6b3018315fb3883124f80948ff2f0a8d017c79454aa28509a19ab9753c2dd1480a476d58e1a0182426068c9ea5b00000000000000000002f84f00000000083e4fda54950000c080a086fbc7bbee41f441fb0f32f7aa274d2188c460fe6ac95095fa6331fa08ec4ce7a01aee3bcc3c28f7ba4e0c24da9ae85e9e0166c73cabb42c25ff7b5ecd424f3105"
+);
+
+pub const TXN_HASH: TxHash =
+    b256!("0x4f7ddfc911f5cf85dd15a413f4cbb2a0abe4f1ff275ed13581958c0bcf043c5e");
+
+pub fn create_bundle_from_txn_data() -> AcceptedBundle {
+    AcceptedBundle::new(
+        Bundle { txs: vec![TXN_DATA], ..Default::default() }.try_into().unwrap(),
+        create_test_meter_bundle_response(),
+    )
+}
+
+pub fn create_transaction(from: PrivateKeySigner, nonce: u64, to: Address) -> OpTxEnvelope {
+    let mut txn = OpTransactionRequest::default()
+        .value(U256::from(10_000))
+        .gas_limit(21_000)
+        .max_fee_per_gas(200)
+        .max_priority_fee_per_gas(100)
+        .from(from.address())
+        .to(to)
+        .nonce(nonce)
+        .build_typed_tx()
+        .unwrap();
+
+    let sig = from.sign_transaction_sync(&mut txn).unwrap();
+    OpTxEnvelope::Eip1559(txn.eip1559().cloned().unwrap().into_signed(sig))
+}
+
+pub fn create_test_bundle(
+    txns: Vec<OpTxEnvelope>,
+    block_number: Option<u64>,
+    min_timestamp: Option<u64>,
+    max_timestamp: Option<u64>,
+) -> AcceptedBundle {
+    let txs = txns.iter().map(|t| t.encoded_2718().into()).collect();
+
+    let bundle = Bundle {
+        txs,
+        block_number: block_number.unwrap_or(0),
+        min_timestamp,
+        max_timestamp,
+        ..Default::default()
+    };
+    let meter_bundle_response = create_test_meter_bundle_response();
+
+    AcceptedBundle::new(bundle.try_into().unwrap(), meter_bundle_response)
+}
+
+pub fn create_test_meter_bundle_response() -> MeterBundleResponse {
+    MeterBundleResponse {
+        bundle_gas_price: U256::from(0),
+        bundle_hash: alloy_primitives::B256::default(),
+        coinbase_diff: U256::from(0),
+        eth_sent_to_coinbase: U256::from(0),
+        gas_fees: U256::from(0),
+        results: vec![],
+        state_block_number: 0,
+        state_flashblock_index: None,
+        total_gas_used: 0,
+        total_execution_time_us: 0,
+        state_root_time_us: 0,
+    }
+}

--- a/crates/audit/src/types.rs
+++ b/crates/audit/src/types.rs
@@ -1,0 +1,318 @@
+use alloy_consensus::transaction::{SignerRecoverable, Transaction as ConsensusTransaction};
+use alloy_primitives::{Address, B256, TxHash, U256};
+use base_bundles::AcceptedBundle;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Unique identifier for a transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TransactionId {
+    /// The sender address.
+    pub sender: Address,
+    /// The transaction nonce.
+    pub nonce: U256,
+    /// The transaction hash.
+    pub hash: TxHash,
+}
+
+/// Unique identifier for a bundle.
+pub type BundleId = Uuid;
+
+/// Reason a bundle was dropped.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DropReason {
+    /// Bundle timed out.
+    TimedOut,
+    /// Bundle transaction reverted.
+    Reverted,
+}
+
+/// A transaction with its data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Transaction {
+    /// Transaction identifier.
+    pub id: TransactionId,
+    /// Raw transaction data.
+    pub data: Bytes,
+}
+
+/// Hash of a user operation.
+pub type UserOpHash = B256;
+
+/// Reason a user operation was dropped.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UserOpDropReason {
+    /// User operation was invalid.
+    Invalid(String),
+    /// User operation expired.
+    Expired,
+    /// Replaced by a higher fee user operation.
+    ReplacedByHigherFee,
+}
+
+/// Bundle lifecycle event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", content = "data")]
+pub enum BundleEvent {
+    /// Bundle was received.
+    Received {
+        /// Bundle identifier.
+        bundle_id: BundleId,
+        /// The accepted bundle.
+        bundle: Box<AcceptedBundle>,
+    },
+    /// Bundle was cancelled.
+    Cancelled {
+        /// Bundle identifier.
+        bundle_id: BundleId,
+    },
+    /// Bundle was included by a builder.
+    BuilderIncluded {
+        /// Bundle identifier.
+        bundle_id: BundleId,
+        /// Builder identifier.
+        builder: String,
+        /// Block number.
+        block_number: u64,
+        /// Flashblock index.
+        flashblock_index: u64,
+    },
+    /// Bundle was included in a block.
+    BlockIncluded {
+        /// Bundle identifier.
+        bundle_id: BundleId,
+        /// Block number.
+        block_number: u64,
+        /// Block hash.
+        block_hash: TxHash,
+    },
+    /// Bundle was dropped.
+    Dropped {
+        /// Bundle identifier.
+        bundle_id: BundleId,
+        /// Drop reason.
+        reason: DropReason,
+    },
+}
+
+impl BundleEvent {
+    /// Returns the bundle ID for this event.
+    pub const fn bundle_id(&self) -> BundleId {
+        match self {
+            Self::Received { bundle_id, .. }
+            | Self::Cancelled { bundle_id, .. }
+            | Self::BuilderIncluded { bundle_id, .. }
+            | Self::BlockIncluded { bundle_id, .. }
+            | Self::Dropped { bundle_id, .. } => *bundle_id,
+        }
+    }
+
+    /// Returns transaction IDs from this event (only for Received events).
+    pub fn transaction_ids(&self) -> Vec<TransactionId> {
+        match self {
+            Self::Received { bundle, .. } => bundle
+                .txs
+                .iter()
+                .filter_map(|envelope| {
+                    envelope.recover_signer().ok().map(|sender| TransactionId {
+                        sender,
+                        nonce: U256::from(envelope.nonce()),
+                        hash: *envelope.hash(),
+                    })
+                })
+                .collect(),
+            Self::Cancelled { .. }
+            | Self::BuilderIncluded { .. }
+            | Self::BlockIncluded { .. }
+            | Self::Dropped { .. } => vec![],
+        }
+    }
+
+    /// Generates a unique event key for this event.
+    pub fn generate_event_key(&self) -> String {
+        match self {
+            Self::BlockIncluded { bundle_id, block_hash, .. } => {
+                format!("{bundle_id}-{block_hash}")
+            }
+            _ => {
+                format!(
+                    "{}-{}",
+                    self.bundle_id(),
+                    Uuid::new_v5(&Uuid::NAMESPACE_OID, self.bundle_id().as_bytes())
+                )
+            }
+        }
+    }
+}
+
+/// User operation lifecycle event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", content = "data")]
+pub enum UserOpEvent {
+    /// User operation was added to the mempool.
+    AddedToMempool {
+        /// Hash of the user operation.
+        user_op_hash: UserOpHash,
+        /// Sender address.
+        sender: Address,
+        /// Entry point address.
+        entry_point: Address,
+        /// Nonce.
+        nonce: U256,
+    },
+    /// User operation was dropped.
+    Dropped {
+        /// Hash of the user operation.
+        user_op_hash: UserOpHash,
+        /// Reason for dropping.
+        reason: UserOpDropReason,
+    },
+    /// User operation was included in a block.
+    Included {
+        /// Hash of the user operation.
+        user_op_hash: UserOpHash,
+        /// Block number.
+        block_number: u64,
+        /// Transaction hash.
+        tx_hash: TxHash,
+    },
+}
+
+impl UserOpEvent {
+    /// Returns the user operation hash for this event.
+    pub const fn user_op_hash(&self) -> UserOpHash {
+        match self {
+            Self::AddedToMempool { user_op_hash, .. }
+            | Self::Dropped { user_op_hash, .. }
+            | Self::Included { user_op_hash, .. } => *user_op_hash,
+        }
+    }
+
+    /// Generates a unique event key for this event.
+    pub fn generate_event_key(&self) -> String {
+        match self {
+            Self::Included { user_op_hash, tx_hash, .. } => {
+                format!("{user_op_hash}-{tx_hash}")
+            }
+            _ => {
+                format!(
+                    "{}-{}",
+                    self.user_op_hash(),
+                    Uuid::new_v5(&Uuid::NAMESPACE_OID, self.user_op_hash().as_slice())
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod user_op_event_tests {
+    use alloy_primitives::{address, b256};
+
+    use super::*;
+
+    fn create_test_user_op_hash() -> UserOpHash {
+        b256!("1111111111111111111111111111111111111111111111111111111111111111")
+    }
+
+    #[test]
+    fn test_user_op_event_added_to_mempool_serialization() {
+        let event = UserOpEvent::AddedToMempool {
+            user_op_hash: create_test_user_op_hash(),
+            sender: address!("2222222222222222222222222222222222222222"),
+            entry_point: address!("0000000071727De22E5E9d8BAf0edAc6f37da032"),
+            nonce: U256::from(1),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"event\":\"AddedToMempool\""));
+
+        let deserialized: UserOpEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event.user_op_hash(), deserialized.user_op_hash());
+    }
+
+    #[test]
+    fn test_user_op_event_dropped_serialization() {
+        let event = UserOpEvent::Dropped {
+            user_op_hash: create_test_user_op_hash(),
+            reason: UserOpDropReason::Invalid("gas too low".to_string()),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"event\":\"Dropped\""));
+        assert!(json.contains("gas too low"));
+
+        let deserialized: UserOpEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event.user_op_hash(), deserialized.user_op_hash());
+    }
+
+    #[test]
+    fn test_user_op_event_included_serialization() {
+        let event = UserOpEvent::Included {
+            user_op_hash: create_test_user_op_hash(),
+            block_number: 12345,
+            tx_hash: b256!("3333333333333333333333333333333333333333333333333333333333333333"),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"event\":\"Included\""));
+        assert!(json.contains("\"block_number\":12345"));
+
+        let deserialized: UserOpEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event.user_op_hash(), deserialized.user_op_hash());
+    }
+
+    #[test]
+    fn test_user_op_hash_accessor() {
+        let hash = create_test_user_op_hash();
+
+        let added = UserOpEvent::AddedToMempool {
+            user_op_hash: hash,
+            sender: address!("2222222222222222222222222222222222222222"),
+            entry_point: address!("0000000071727De22E5E9d8BAf0edAc6f37da032"),
+            nonce: U256::from(1),
+        };
+        assert_eq!(added.user_op_hash(), hash);
+
+        let dropped =
+            UserOpEvent::Dropped { user_op_hash: hash, reason: UserOpDropReason::Expired };
+        assert_eq!(dropped.user_op_hash(), hash);
+
+        let included = UserOpEvent::Included {
+            user_op_hash: hash,
+            block_number: 100,
+            tx_hash: b256!("4444444444444444444444444444444444444444444444444444444444444444"),
+        };
+        assert_eq!(included.user_op_hash(), hash);
+    }
+
+    #[test]
+    fn test_generate_event_key_included() {
+        let user_op_hash =
+            b256!("1111111111111111111111111111111111111111111111111111111111111111");
+        let tx_hash = b256!("2222222222222222222222222222222222222222222222222222222222222222");
+
+        let event = UserOpEvent::Included { user_op_hash, block_number: 100, tx_hash };
+
+        let key = event.generate_event_key();
+        assert!(key.contains(&format!("{user_op_hash}")));
+        assert!(key.contains(&format!("{tx_hash}")));
+    }
+
+    #[test]
+    fn test_user_op_drop_reason_variants() {
+        let invalid = UserOpDropReason::Invalid("test reason".to_string());
+        let json = serde_json::to_string(&invalid).unwrap();
+        assert!(json.contains("Invalid"));
+        assert!(json.contains("test reason"));
+
+        let expired = UserOpDropReason::Expired;
+        let json = serde_json::to_string(&expired).unwrap();
+        assert!(json.contains("Expired"));
+
+        let replaced = UserOpDropReason::ReplacedByHigherFee;
+        let json = serde_json::to_string(&replaced).unwrap();
+        assert!(json.contains("ReplacedByHigherFee"));
+    }
+}

--- a/crates/audit/tests/common/mod.rs
+++ b/crates/audit/tests/common/mod.rs
@@ -1,0 +1,75 @@
+use audit::test_utils::create_bundle_from_txn_data;
+use base_bundles::BundleExtensions;
+use rdkafka::{ClientConfig, consumer::StreamConsumer, producer::FutureProducer};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::{kafka, kafka::Kafka, minio::MinIO};
+use uuid::Uuid;
+
+pub(crate) struct TestHarness {
+    pub s3_client: aws_sdk_s3::Client,
+    pub bucket_name: String,
+    #[allow(dead_code)] // TODO is read
+    pub kafka_producer: FutureProducer,
+    #[allow(dead_code)] // TODO is read
+    pub kafka_consumer: StreamConsumer,
+    _minio_container: testcontainers::ContainerAsync<MinIO>,
+    _kafka_container: testcontainers::ContainerAsync<Kafka>,
+}
+
+impl TestHarness {
+    pub(crate) async fn new() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let minio_container = MinIO::default().start().await?;
+        let s3_port = minio_container.get_host_port_ipv4(9000).await?;
+        let s3_endpoint = format!("http://127.0.0.1:{s3_port}");
+
+        let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region("us-east-1")
+            .endpoint_url(&s3_endpoint)
+            .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                "minioadmin",
+                "minioadmin",
+                None,
+                None,
+                "test",
+            ))
+            .load()
+            .await;
+
+        let s3_client = aws_sdk_s3::Client::new(&config);
+        let bundle = create_bundle_from_txn_data();
+        let bucket_name = format!(
+            "test-bucket-{}",
+            Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice())
+        );
+
+        s3_client.create_bucket().bucket(&bucket_name).send().await?;
+
+        let kafka_container = Kafka::default().start().await?;
+        let bootstrap_servers =
+            format!("127.0.0.1:{}", kafka_container.get_host_port_ipv4(kafka::KAFKA_PORT).await?);
+
+        let kafka_producer = ClientConfig::new()
+            .set("bootstrap.servers", &bootstrap_servers)
+            .set("message.timeout.ms", "5000")
+            .create::<FutureProducer>()
+            .expect("Failed to create Kafka FutureProducer");
+
+        let kafka_consumer = ClientConfig::new()
+            .set("group.id", "testcontainer-rs")
+            .set("bootstrap.servers", &bootstrap_servers)
+            .set("session.timeout.ms", "6000")
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .create::<StreamConsumer>()
+            .expect("Failed to create Kafka StreamConsumer");
+
+        Ok(Self {
+            s3_client,
+            bucket_name,
+            kafka_producer,
+            kafka_consumer,
+            _minio_container: minio_container,
+            _kafka_container: kafka_container,
+        })
+    }
+}

--- a/crates/audit/tests/integration_tests.rs
+++ b/crates/audit/tests/integration_tests.rs
@@ -1,0 +1,117 @@
+#![allow(missing_docs)]
+
+use std::time::Duration;
+
+use alloy_primitives::{Address, B256, U256};
+use audit::{
+    BundleEvent, BundleEventPublisher, BundleEventS3Reader, DropReason, KafkaAuditArchiver,
+    KafkaAuditLogReader, KafkaBundleEventPublisher, KafkaUserOpAuditLogReader,
+    KafkaUserOpEventPublisher, S3EventReaderWriter, UserOpEvent, UserOpEventPublisher,
+    UserOpEventReader, test_utils::create_bundle_from_txn_data,
+};
+use base_bundles::BundleExtensions;
+use uuid::Uuid;
+
+mod common;
+
+use common::TestHarness;
+
+#[tokio::test]
+#[ignore = "TODO doesn't appear to work with minio, should test against a real S3 bucket"]
+async fn test_kafka_publisher_s3_archiver_integration()
+-> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let topic = "test-mempool-events";
+
+    let s3_writer =
+        S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let bundle = create_bundle_from_txn_data();
+    let test_bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+    let test_events = [
+        BundleEvent::Received { bundle_id: test_bundle_id, bundle: Box::new(bundle.clone()) },
+        BundleEvent::Dropped { bundle_id: test_bundle_id, reason: DropReason::TimedOut },
+    ];
+
+    let publisher = KafkaBundleEventPublisher::new(harness.kafka_producer, topic.to_string());
+
+    for event in &test_events {
+        publisher.publish(event.clone()).await?;
+    }
+
+    let mut consumer = KafkaAuditArchiver::new(
+        KafkaAuditLogReader::new(harness.kafka_consumer, topic.to_string())?,
+        s3_writer.clone(),
+        1,
+        100,
+        false,
+    );
+
+    tokio::spawn(async move {
+        consumer.run().await.expect("error running consumer");
+    });
+
+    // Wait for the messages to be received
+    let mut counter = 0;
+    loop {
+        counter += 1;
+        if counter > 10 {
+            panic!("unable to complete archiving within the deadline");
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let bundle_history = s3_writer.get_bundle_history(test_bundle_id).await?;
+
+        if let Some(history) = bundle_history {
+            if history.history.len() != test_events.len() {
+                continue;
+            }
+            break;
+        }
+        continue;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_userop_kafka_publisher_reader_integration()
+-> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let topic = "test-userop-events";
+
+    let test_user_op_hash = B256::from_slice(&[1u8; 32]);
+    let test_sender = Address::from_slice(&[2u8; 20]);
+    let test_entry_point = Address::from_slice(&[3u8; 20]);
+    let test_nonce = U256::from(42);
+
+    let test_event = UserOpEvent::AddedToMempool {
+        user_op_hash: test_user_op_hash,
+        sender: test_sender,
+        entry_point: test_entry_point,
+        nonce: test_nonce,
+    };
+
+    let publisher = KafkaUserOpEventPublisher::new(harness.kafka_producer, topic.to_string());
+    publisher.publish(test_event.clone()).await?;
+
+    let mut reader = KafkaUserOpAuditLogReader::new(harness.kafka_consumer, topic.to_string())?;
+
+    let received = tokio::time::timeout(Duration::from_secs(10), reader.read_event()).await??;
+
+    assert_eq!(received.event.user_op_hash(), test_user_op_hash);
+
+    match received.event {
+        UserOpEvent::AddedToMempool { user_op_hash, sender, entry_point, nonce } => {
+            assert_eq!(user_op_hash, test_user_op_hash);
+            assert_eq!(sender, test_sender);
+            assert_eq!(entry_point, test_entry_point);
+            assert_eq!(nonce, test_nonce);
+        }
+        _ => panic!("Expected AddedToMempool event"),
+    }
+
+    reader.commit().await?;
+
+    Ok(())
+}

--- a/crates/audit/tests/s3_test.rs
+++ b/crates/audit/tests/s3_test.rs
@@ -1,0 +1,395 @@
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, TxHash, U256};
+use audit::{
+    BundleEvent, BundleEventS3Reader, Event, EventWriter, S3EventReaderWriter, UserOpDropReason,
+    UserOpEvent, UserOpEventS3Reader, UserOpEventWrapper, UserOpEventWriter,
+    test_utils::{TXN_HASH, create_bundle_from_txn_data},
+};
+use base_bundles::BundleExtensions;
+use tokio::task::JoinSet;
+use uuid::Uuid;
+
+mod common;
+use common::TestHarness;
+
+fn create_test_event(key: &str, timestamp: i64, bundle_event: BundleEvent) -> Event {
+    Event { key: key.to_string(), timestamp, event: bundle_event }
+}
+
+#[tokio::test]
+async fn test_event_write_and_read() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let bundle = create_bundle_from_txn_data();
+    let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+    let event = create_test_event(
+        "test-key-1",
+        1234567890,
+        BundleEvent::Received { bundle_id, bundle: Box::new(bundle.clone()) },
+    );
+
+    writer.archive_event(event).await?;
+
+    let bundle_history = writer.get_bundle_history(bundle_id).await?;
+    assert!(bundle_history.is_some());
+
+    let history = bundle_history.unwrap();
+    assert_eq!(history.history.len(), 1);
+    assert_eq!(history.history[0].key(), "test-key-1");
+
+    let metadata = writer.get_transaction_metadata(TXN_HASH).await?;
+    assert!(metadata.is_some());
+
+    if let Some(metadata) = metadata {
+        assert!(metadata.bundle_ids.contains(&bundle_id));
+    }
+
+    let bundle_id_two = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+    let bundle = create_bundle_from_txn_data();
+    let event = create_test_event(
+        "test-key-2",
+        1234567890,
+        BundleEvent::Received { bundle_id: bundle_id_two, bundle: Box::new(bundle.clone()) },
+    );
+
+    writer.archive_event(event).await?;
+
+    let metadata = writer.get_transaction_metadata(TXN_HASH).await?;
+    assert!(metadata.is_some());
+
+    if let Some(metadata) = metadata {
+        assert!(metadata.bundle_ids.contains(&bundle_id));
+        assert!(metadata.bundle_ids.contains(&bundle_id_two));
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_events_appended() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let bundle = create_bundle_from_txn_data();
+    let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+
+    let events = [
+        create_test_event(
+            "test-key-1",
+            1234567890,
+            BundleEvent::Received { bundle_id, bundle: Box::new(bundle.clone()) },
+        ),
+        create_test_event("test-key-2", 1234567891, BundleEvent::Cancelled { bundle_id }),
+    ];
+
+    for (idx, event) in events.iter().enumerate() {
+        writer.archive_event(event.clone()).await?;
+
+        let bundle_history = writer.get_bundle_history(bundle_id).await?;
+        assert!(bundle_history.is_some());
+
+        let history = bundle_history.unwrap();
+        assert_eq!(history.history.len(), idx + 1);
+
+        let keys: Vec<String> = history.history.iter().map(|e| e.key().to_string()).collect();
+        assert_eq!(
+            keys,
+            events.iter().map(|e| e.key.clone()).take(idx + 1).collect::<Vec<String>>()
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_event_deduplication() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let bundle = create_bundle_from_txn_data();
+    let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+    let bundle = create_bundle_from_txn_data();
+    let event = create_test_event(
+        "duplicate-key",
+        1234567890,
+        BundleEvent::Received { bundle_id, bundle: Box::new(bundle.clone()) },
+    );
+
+    writer.archive_event(event.clone()).await?;
+    writer.archive_event(event).await?;
+
+    let bundle_history = writer.get_bundle_history(bundle_id).await?;
+    assert!(bundle_history.is_some());
+
+    let history = bundle_history.unwrap();
+    assert_eq!(history.history.len(), 1);
+    assert_eq!(history.history[0].key(), "duplicate-key");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_nonexistent_data() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let bundle = create_bundle_from_txn_data();
+    let nonexistent_bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+    let bundle_history = writer.get_bundle_history(nonexistent_bundle_id).await?;
+    assert!(bundle_history.is_none());
+
+    let nonexistent_tx_hash = TxHash::from([255u8; 32]);
+    let metadata = writer.get_transaction_metadata(nonexistent_tx_hash).await?;
+    assert!(metadata.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "TODO doesn't appear to work with minio, should test against a real S3 bucket"]
+async fn test_concurrent_writes_for_bundle() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+{
+    let harness = TestHarness::new().await?;
+    let writer =
+        Arc::new(S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone()));
+
+    let bundle = create_bundle_from_txn_data();
+    let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+
+    let event = create_test_event(
+        "hello-dan",
+        1234567889i64,
+        BundleEvent::Received { bundle_id, bundle: Box::new(bundle.clone()) },
+    );
+
+    writer.archive_event(event.clone()).await?;
+
+    let mut join_set: JoinSet<Result<(), Box<dyn std::error::Error + Send + Sync>>> =
+        JoinSet::new();
+
+    for i in 0..4 {
+        let writer_clone = Arc::clone(&writer);
+        let key = if i % 4 == 0 { "shared-key".to_string() } else { format!("unique-key-{i}") };
+
+        let event = create_test_event(
+            &key,
+            1234567890 + i as i64,
+            BundleEvent::Received { bundle_id, bundle: Box::new(bundle.clone()) },
+        );
+
+        join_set.spawn(async move {
+            writer_clone.archive_event(event.clone()).await.map_err(|e| e.into())
+        });
+    }
+
+    let tasks = join_set.join_all().await;
+    assert_eq!(tasks.len(), 4);
+    for t in &tasks {
+        assert!(t.is_ok());
+    }
+
+    let bundle_history = writer.get_bundle_history(bundle_id).await?;
+    assert!(bundle_history.is_some());
+
+    let history = bundle_history.unwrap();
+
+    let shared_count = history.history.iter().filter(|e| e.key() == "shared-key").count();
+    assert_eq!(shared_count, 1);
+
+    let unique_count =
+        history.history.iter().filter(|e| e.key().starts_with("unique-key-")).count();
+    assert_eq!(unique_count, 3);
+
+    assert_eq!(history.history.len(), 4);
+
+    Ok(())
+}
+
+fn create_test_userop_event(
+    key: &str,
+    timestamp: i64,
+    userop_event: UserOpEvent,
+) -> UserOpEventWrapper {
+    UserOpEventWrapper { key: key.to_string(), timestamp, event: userop_event }
+}
+
+#[tokio::test]
+async fn test_userop_event_write_and_read() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+{
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let user_op_hash = B256::from([1u8; 32]);
+    let sender = Address::from([2u8; 20]);
+    let entry_point = Address::from([3u8; 20]);
+    let nonce = U256::from(1);
+
+    let event = create_test_userop_event(
+        "test-userop-key-1",
+        1234567890,
+        UserOpEvent::AddedToMempool { user_op_hash, sender, entry_point, nonce },
+    );
+
+    writer.archive_userop_event(event).await?;
+
+    let userop_history = writer.get_userop_history(user_op_hash).await?;
+    assert!(userop_history.is_some());
+
+    let history = userop_history.unwrap();
+    assert_eq!(history.history.len(), 1);
+    assert_eq!(history.history[0].key(), "test-userop-key-1");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_userop_events_appended() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let user_op_hash = B256::from([10u8; 32]);
+    let sender = Address::from([11u8; 20]);
+    let entry_point = Address::from([12u8; 20]);
+    let nonce = U256::from(1);
+    let tx_hash = TxHash::from([13u8; 32]);
+
+    let events = [
+        create_test_userop_event(
+            "userop-key-1",
+            1234567890,
+            UserOpEvent::AddedToMempool { user_op_hash, sender, entry_point, nonce },
+        ),
+        create_test_userop_event(
+            "userop-key-2",
+            1234567891,
+            UserOpEvent::Included { user_op_hash, block_number: 12345, tx_hash },
+        ),
+    ];
+
+    for (idx, event) in events.iter().enumerate() {
+        writer.archive_userop_event(event.clone()).await?;
+
+        let userop_history = writer.get_userop_history(user_op_hash).await?;
+        assert!(userop_history.is_some());
+
+        let history = userop_history.unwrap();
+        assert_eq!(history.history.len(), idx + 1);
+
+        let keys: Vec<String> = history.history.iter().map(|e| e.key().to_string()).collect();
+        assert_eq!(
+            keys,
+            events.iter().map(|e| e.key.clone()).take(idx + 1).collect::<Vec<String>>()
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_userop_event_deduplication() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let user_op_hash = B256::from([20u8; 32]);
+    let sender = Address::from([21u8; 20]);
+    let entry_point = Address::from([22u8; 20]);
+    let nonce = U256::from(1);
+
+    let event = create_test_userop_event(
+        "duplicate-userop-key",
+        1234567890,
+        UserOpEvent::AddedToMempool { user_op_hash, sender, entry_point, nonce },
+    );
+
+    writer.archive_userop_event(event.clone()).await?;
+    writer.archive_userop_event(event).await?;
+
+    let userop_history = writer.get_userop_history(user_op_hash).await?;
+    assert!(userop_history.is_some());
+
+    let history = userop_history.unwrap();
+    assert_eq!(history.history.len(), 1);
+    assert_eq!(history.history[0].key(), "duplicate-userop-key");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_userop_nonexistent_returns_none()
+-> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let nonexistent_hash = B256::from([255u8; 32]);
+    let userop_history = writer.get_userop_history(nonexistent_hash).await?;
+    assert!(userop_history.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_userop_all_event_types() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let user_op_hash = B256::from([30u8; 32]);
+    let sender = Address::from([31u8; 20]);
+    let entry_point = Address::from([32u8; 20]);
+    let nonce = U256::from(1);
+    let tx_hash = TxHash::from([33u8; 32]);
+
+    let event1 = create_test_userop_event(
+        "event-added",
+        1234567890,
+        UserOpEvent::AddedToMempool { user_op_hash, sender, entry_point, nonce },
+    );
+    writer.archive_userop_event(event1).await?;
+
+    let event2 = create_test_userop_event(
+        "event-included",
+        1234567891,
+        UserOpEvent::Included { user_op_hash, block_number: 12345, tx_hash },
+    );
+    writer.archive_userop_event(event2).await?;
+
+    let userop_history = writer.get_userop_history(user_op_hash).await?;
+    assert!(userop_history.is_some());
+
+    let history = userop_history.unwrap();
+    assert_eq!(history.history.len(), 2);
+    assert_eq!(history.history[0].key(), "event-added");
+    assert_eq!(history.history[1].key(), "event-included");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_userop_dropped_event() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let harness = TestHarness::new().await?;
+    let writer = S3EventReaderWriter::new(harness.s3_client.clone(), harness.bucket_name.clone());
+
+    let user_op_hash = B256::from([40u8; 32]);
+
+    let event = create_test_userop_event(
+        "event-dropped",
+        1234567890,
+        UserOpEvent::Dropped {
+            user_op_hash,
+            reason: UserOpDropReason::Invalid("AA21 didn't pay prefund".to_string()),
+        },
+    );
+    writer.archive_userop_event(event).await?;
+
+    let userop_history = writer.get_userop_history(user_op_hash).await?;
+    assert!(userop_history.is_some());
+
+    let history = userop_history.unwrap();
+    assert_eq!(history.history.len(), 1);
+    assert_eq!(history.history[0].key(), "event-dropped");
+
+    Ok(())
+}

--- a/crates/ingress-rpc/Cargo.toml
+++ b/crates/ingress-rpc/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "ingress-rpc"
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[dependencies]
+url.workspace = true
+utils.workspace = true
+op-revm.workspace = true
+metrics.workspace = true
+audit.workspace = true
+async-trait.workspace = true
+metrics-derive.workspace = true
+op-alloy-network.workspace = true
+alloy-signer-local.workspace = true
+base-reth-rpc-types.workspace = true
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true, features = ["std"] }
+anyhow = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+rdkafka = { workspace = true, features = ["tokio", "libz", "zstd", "ssl-vendored"] }
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+jsonrpsee = { workspace = true, features = ["server", "macros"] }
+backon = { workspace = true, features = ["std", "tokio-sleep"] }
+axum = { workspace = true, features = ["tokio", "http1", "json"] }
+clap = { version = "4.5.47", features = ["std", "derive", "env"] }
+op-alloy-consensus = { workspace = true, features = ["std", "k256", "serde"] }
+moka = { workspace = true, features = ["future"] }
+uuid = { workspace = true, features = ["v5"] }
+base-bundles = { workspace = true }
+
+[dev-dependencies]
+mockall = "0.13"
+wiremock.workspace = true
+jsonrpsee = { workspace = true, features = ["server", "http-client", "macros"] }

--- a/crates/ingress-rpc/src/health.rs
+++ b/crates/ingress-rpc/src/health.rs
@@ -1,0 +1,32 @@
+use std::net::SocketAddr;
+
+use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
+use tracing::info;
+
+/// Health check handler that always returns 200 OK
+async fn health() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+/// Bind and start the health check server on the specified address.
+/// Returns a handle that can be awaited to run the server.
+pub async fn bind_health_server(
+    addr: SocketAddr,
+) -> anyhow::Result<(SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>)> {
+    let app = Router::new().route("/health", get(health));
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let bound_addr = listener.local_addr()?;
+
+    info!(
+        message = "Health check server bound successfully",
+        address = %bound_addr
+    );
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await?;
+        Ok(())
+    });
+
+    Ok((bound_addr, handle))
+}

--- a/crates/ingress-rpc/src/lib.rs
+++ b/crates/ingress-rpc/src/lib.rs
@@ -1,0 +1,199 @@
+pub mod health;
+pub mod metrics;
+pub mod queue;
+pub mod service;
+pub mod validation;
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
+
+use alloy_primitives::TxHash;
+use alloy_provider::{Provider, ProviderBuilder, RootProvider};
+use base_bundles::{AcceptedBundle, MeterBundleResponse};
+use clap::Parser;
+use op_alloy_network::Optimism;
+use tokio::sync::broadcast;
+use tracing::{error, warn};
+use url::Url;
+
+#[derive(Debug, Clone, Copy)]
+pub enum TxSubmissionMethod {
+    Mempool,
+    Kafka,
+    MempoolAndKafka,
+    None,
+}
+
+impl FromStr for TxSubmissionMethod {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "mempool" => Ok(TxSubmissionMethod::Mempool),
+            "kafka" => Ok(TxSubmissionMethod::Kafka),
+            "mempool,kafka" | "kafka,mempool" => Ok(TxSubmissionMethod::MempoolAndKafka),
+            "none" => Ok(TxSubmissionMethod::None),
+            _ => Err(format!(
+                "Invalid submission method: '{s}'. Valid options: mempool, kafka, mempool,kafka, kafka,mempool, none"
+            )),
+        }
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+pub struct Config {
+    /// Address to bind the RPC server to
+    #[arg(long, env = "TIPS_INGRESS_ADDRESS", default_value = "0.0.0.0")]
+    pub address: IpAddr,
+
+    /// Port to bind the RPC server to
+    #[arg(long, env = "TIPS_INGRESS_PORT", default_value = "8080")]
+    pub port: u16,
+
+    /// URL of the mempool service to proxy transactions to
+    #[arg(long, env = "TIPS_INGRESS_RPC_MEMPOOL")]
+    pub mempool_url: Url,
+
+    /// Method to submit transactions to the mempool
+    #[arg(long, env = "TIPS_INGRESS_TX_SUBMISSION_METHOD", default_value = "mempool")]
+    pub tx_submission_method: TxSubmissionMethod,
+
+    /// Kafka brokers for publishing mempool events
+    #[arg(long, env = "TIPS_INGRESS_KAFKA_INGRESS_PROPERTIES_FILE")]
+    pub ingress_kafka_properties: String,
+
+    /// Kafka topic for queuing transactions before the DB Writer
+    #[arg(long, env = "TIPS_INGRESS_KAFKA_INGRESS_TOPIC", default_value = "tips-ingress")]
+    pub ingress_topic: String,
+
+    /// Kafka properties file for audit events
+    #[arg(long, env = "TIPS_INGRESS_KAFKA_AUDIT_PROPERTIES_FILE")]
+    pub audit_kafka_properties: String,
+
+    /// Kafka topic for audit events
+    #[arg(long, env = "TIPS_INGRESS_KAFKA_AUDIT_TOPIC", default_value = "tips-audit")]
+    pub audit_topic: String,
+
+    #[arg(long, env = "TIPS_INGRESS_LOG_LEVEL", default_value = "info")]
+    pub log_level: String,
+
+    #[arg(long, env = "TIPS_INGRESS_LOG_FORMAT", default_value = "pretty")]
+    pub log_format: utils::logger::LogFormat,
+
+    /// Default lifetime for sent transactions in seconds (default: 3 hours)
+    #[arg(
+        long,
+        env = "TIPS_INGRESS_SEND_TRANSACTION_DEFAULT_LIFETIME_SECONDS",
+        default_value = "10800"
+    )]
+    pub send_transaction_default_lifetime_seconds: u64,
+
+    /// URL of the simulation RPC service for bundle metering
+    #[arg(long, env = "TIPS_INGRESS_RPC_SIMULATION")]
+    pub simulation_rpc: Url,
+
+    /// Port to bind the Prometheus metrics server to
+    #[arg(long, env = "TIPS_INGRESS_METRICS_ADDR", default_value = "0.0.0.0:9002")]
+    pub metrics_addr: SocketAddr,
+
+    /// Configurable block time in milliseconds (default: 2000 milliseconds)
+    #[arg(long, env = "TIPS_INGRESS_BLOCK_TIME_MILLISECONDS", default_value = "2000")]
+    pub block_time_milliseconds: u64,
+
+    /// Timeout for bundle metering in milliseconds (default: 2000 milliseconds)
+    #[arg(long, env = "TIPS_INGRESS_METER_BUNDLE_TIMEOUT_MS", default_value = "2000")]
+    pub meter_bundle_timeout_ms: u64,
+
+    /// URLs of the builder RPC service for setting metering information
+    #[arg(long, env = "TIPS_INGRESS_BUILDER_RPCS", value_delimiter = ',')]
+    pub builder_rpcs: Vec<Url>,
+
+    /// Maximum number of `MeterBundleResponse`s to buffer in memory
+    #[arg(long, env = "TIPS_INGRESS_MAX_BUFFERED_METER_BUNDLE_RESPONSES", default_value = "100")]
+    pub max_buffered_meter_bundle_responses: usize,
+
+    /// Maximum number of backrun bundles to buffer in memory
+    #[arg(long, env = "TIPS_INGRESS_MAX_BUFFERED_BACKRUN_BUNDLES", default_value = "100")]
+    pub max_buffered_backrun_bundles: usize,
+
+    /// Address to bind the health check server to
+    #[arg(long, env = "TIPS_INGRESS_HEALTH_CHECK_ADDR", default_value = "0.0.0.0:8081")]
+    pub health_check_addr: SocketAddr,
+
+    /// chain id
+    #[arg(long, env = "TIPS_INGRESS_CHAIN_ID", default_value = "11")]
+    pub chain_id: u64,
+
+    /// Enable backrun bundle submission to op-rbuilder
+    #[arg(long, env = "TIPS_INGRESS_BACKRUN_ENABLED", default_value = "false")]
+    pub backrun_enabled: bool,
+
+    /// Maximum number of transactions allowed in a backrun bundle (including target tx)
+    #[arg(long, env = "MAX_BACKRUN_TXS", default_value = "5")]
+    pub max_backrun_txs: usize,
+
+    /// Maximum total gas limit for all transactions in a backrun bundle
+    #[arg(long, env = "MAX_BACKRUN_GAS_LIMIT", default_value = "5000000")]
+    pub max_backrun_gas_limit: u64,
+
+    /// URL of third-party RPC endpoint to forward raw transactions to (enables forwarding if set)
+    #[arg(long, env = "TIPS_INGRESS_RAW_TX_FORWARD_RPC")]
+    pub raw_tx_forward_rpc: Option<Url>,
+
+    /// TTL for bundle cache in seconds
+    #[arg(long, env = "TIPS_INGRESS_BUNDLE_CACHE_TTL", default_value = "20")]
+    pub bundle_cache_ttl: u64,
+
+    /// Enable sending to builder
+    #[arg(long, env = "TIPS_INGRESS_SEND_TO_BUILDER", default_value = "false")]
+    pub send_to_builder: bool,
+}
+
+pub fn connect_ingress_to_builder(
+    metering_rx: broadcast::Receiver<MeterBundleResponse>,
+    backrun_rx: broadcast::Receiver<AcceptedBundle>,
+    builder_rpc: Url,
+) {
+    let builder: RootProvider<Optimism> = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .network::<Optimism>()
+        .connect_http(builder_rpc);
+
+    let metering_builder = builder.clone();
+    tokio::spawn(async move {
+        let mut event_rx = metering_rx;
+        while let Ok(event) = event_rx.recv().await {
+            if event.results.is_empty() {
+                warn!(message = "received metering information with no transactions", hash=%event.bundle_hash);
+                continue;
+            }
+
+            let tx_hash = event.results[0].tx_hash;
+            if let Err(e) = metering_builder
+                .client()
+                .request::<(TxHash, MeterBundleResponse), ()>(
+                    "base_setMeteringInformation",
+                    (tx_hash, event),
+                )
+                .await
+            {
+                error!(error = %e, "Failed to set metering information for tx hash: {tx_hash}");
+            }
+        }
+    });
+
+    tokio::spawn(async move {
+        let mut event_rx = backrun_rx;
+        while let Ok(accepted_bundle) = event_rx.recv().await {
+            if let Err(e) = builder
+                .client()
+                .request::<(AcceptedBundle,), ()>("base_sendBackrunBundle", (accepted_bundle,))
+                .await
+            {
+                error!(error = ?e, "Failed to send backrun bundle to builder");
+            }
+        }
+    });
+}

--- a/crates/ingress-rpc/src/metrics.rs
+++ b/crates/ingress-rpc/src/metrics.rs
@@ -1,0 +1,54 @@
+use metrics::{Counter, Histogram};
+use metrics_derive::Metrics;
+use tokio::time::Duration;
+
+pub fn record_histogram(rpc_latency: Duration, rpc: String) {
+    metrics::histogram!("tips_ingress_rpc_rpc_latency", "rpc" => rpc)
+        .record(rpc_latency.as_secs_f64());
+}
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "tips_ingress_rpc")]
+pub struct Metrics {
+    #[metric(describe = "Number of valid transactions received")]
+    pub transactions_received: Counter,
+
+    #[metric(describe = "Number of valid bundles parsed")]
+    pub bundles_parsed: Counter,
+
+    #[metric(describe = "Number of bundles simulated")]
+    pub successful_simulations: Counter,
+
+    #[metric(describe = "Number of bundles simulated")]
+    pub failed_simulations: Counter,
+
+    #[metric(describe = "Number of bundles sent to kafka")]
+    pub sent_to_kafka: Counter,
+
+    #[metric(describe = "Number of transactions sent to mempool")]
+    pub sent_to_mempool: Counter,
+
+    #[metric(describe = "Duration of validate_tx")]
+    pub validate_tx_duration: Histogram,
+
+    #[metric(describe = "Duration of validate_bundle")]
+    pub validate_bundle_duration: Histogram,
+
+    #[metric(describe = "Duration of meter_bundle")]
+    pub meter_bundle_duration: Histogram,
+
+    #[metric(describe = "Duration of send_raw_transaction")]
+    pub send_raw_transaction_duration: Histogram,
+
+    #[metric(describe = "Total backrun bundles received")]
+    pub backrun_bundles_received_total: Counter,
+
+    #[metric(describe = "Duration to send backrun bundle to op-rbuilder")]
+    pub backrun_bundles_sent_duration: Histogram,
+
+    #[metric(describe = "Total raw transactions forwarded to additional endpoint")]
+    pub raw_tx_forwards_total: Counter,
+
+    #[metric(describe = "Number of bundles that exceeded the metering time")]
+    pub bundles_exceeded_metering_time: Counter,
+}

--- a/crates/ingress-rpc/src/queue.rs
+++ b/crates/ingress-rpc/src/queue.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use anyhow::Result;
+use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
+use base_bundles::AcceptedBundle;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use tokio::time::Duration;
+use tracing::{error, info};
+
+#[async_trait]
+pub trait MessageQueue: Send + Sync {
+    async fn publish(&self, topic: &str, key: &str, payload: &[u8]) -> Result<()>;
+}
+
+pub struct KafkaMessageQueue {
+    producer: FutureProducer,
+}
+
+impl KafkaMessageQueue {
+    pub fn new(producer: FutureProducer) -> Self {
+        Self { producer }
+    }
+}
+
+#[async_trait]
+impl MessageQueue for KafkaMessageQueue {
+    async fn publish(&self, topic: &str, key: &str, payload: &[u8]) -> Result<()> {
+        let enqueue = || async {
+            let record = FutureRecord::to(topic).key(key).payload(payload);
+
+            match self.producer.send(record, Duration::from_secs(5)).await {
+                Ok((partition, offset)) => {
+                    info!(
+                        key = %key,
+                        partition = partition,
+                        offset = offset,
+                        topic = %topic,
+                        "Successfully enqueued message"
+                    );
+                    Ok(())
+                }
+                Err((err, _)) => {
+                    error!(
+                        key = key,
+                        error = %err,
+                        topic = topic,
+                        "Failed to enqueue message"
+                    );
+                    Err(anyhow::anyhow!("Failed to enqueue bundle: {err}"))
+                }
+            }
+        };
+
+        enqueue
+            .retry(
+                &ExponentialBuilder::default()
+                    .with_min_delay(Duration::from_millis(100))
+                    .with_max_delay(Duration::from_secs(5))
+                    .with_max_times(3),
+            )
+            .notify(|err: &anyhow::Error, dur: Duration| {
+                info!("retrying to enqueue message {:?} after {:?}", err, dur);
+            })
+            .await
+    }
+}
+
+pub struct BundleQueuePublisher<Q: MessageQueue> {
+    queue: Arc<Q>,
+    topic: String,
+}
+
+impl<Q: MessageQueue> BundleQueuePublisher<Q> {
+    pub fn new(queue: Arc<Q>, topic: String) -> Self {
+        Self { queue, topic }
+    }
+
+    pub async fn publish(&self, bundle: &AcceptedBundle, hash: &B256) -> Result<()> {
+        let key = hash.to_string();
+        let payload = serde_json::to_vec(bundle)?;
+        self.queue.publish(&self.topic, &key, &payload).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use audit::test_utils::create_test_meter_bundle_response;
+    use base_bundles::{AcceptedBundle, Bundle, BundleExtensions};
+    use rdkafka::config::ClientConfig;
+    use tokio::time::{Duration, Instant};
+
+    use super::*;
+
+    fn create_test_bundle() -> Bundle {
+        Bundle::default()
+    }
+
+    #[tokio::test]
+    async fn test_backoff_retry_logic() {
+        // use an invalid broker address to trigger the backoff logic
+        let producer = ClientConfig::new()
+            .set("bootstrap.servers", "localhost:9999")
+            .set("message.timeout.ms", "100")
+            .create()
+            .expect("Producer creation failed");
+
+        let publisher = KafkaMessageQueue::new(producer);
+        let bundle = create_test_bundle();
+        let accepted_bundle =
+            AcceptedBundle::new(bundle.try_into().unwrap(), create_test_meter_bundle_response());
+        let bundle_hash = &accepted_bundle.bundle_hash();
+
+        let start = Instant::now();
+        let result = publisher
+            .publish(
+                "tips-ingress-rpc",
+                bundle_hash.to_string().as_str(),
+                &serde_json::to_vec(&accepted_bundle).unwrap(),
+            )
+            .await;
+        let elapsed = start.elapsed();
+
+        // the backoff tries at minimum 100ms, so verify we tried at least once
+        assert!(result.is_err());
+        assert!(elapsed >= Duration::from_millis(100));
+    }
+}

--- a/crates/ingress-rpc/src/service.rs
+++ b/crates/ingress-rpc/src/service.rs
@@ -1,0 +1,709 @@
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use alloy_consensus::{
+    Transaction,
+    transaction::{Recovered, SignerRecoverable},
+};
+use alloy_primitives::{B256, Bytes};
+use alloy_provider::{Provider, RootProvider, network::eip2718::Decodable2718};
+use audit::BundleEvent;
+use base_bundles::{
+    AcceptedBundle, Bundle, BundleExtensions, BundleHash, CancelBundle, MeterBundleResponse,
+    ParsedBundle,
+};
+use base_reth_rpc_types::EthApiError;
+use jsonrpsee::{
+    core::{RpcResult, async_trait},
+    proc_macros::rpc,
+};
+use moka::future::Cache;
+use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_network::Optimism;
+use tokio::{
+    sync::{broadcast, mpsc},
+    time::{Duration, Instant, timeout},
+};
+use tracing::{debug, info, warn};
+
+use crate::{
+    Config, TxSubmissionMethod,
+    metrics::{Metrics, record_histogram},
+    queue::{BundleQueuePublisher, MessageQueue},
+    validation::validate_bundle,
+};
+
+/// RPC providers for different endpoints
+pub struct Providers {
+    pub mempool: RootProvider<Optimism>,
+    pub simulation: RootProvider<Optimism>,
+    pub raw_tx_forward: Option<RootProvider<Optimism>>,
+}
+
+#[rpc(server, namespace = "eth")]
+pub trait IngressApi {
+    /// `eth_sendBundle` can be used to send your bundles to the builder.
+    #[method(name = "sendBundle")]
+    async fn send_bundle(&self, bundle: Bundle) -> RpcResult<BundleHash>;
+
+    #[method(name = "sendBackrunBundle")]
+    async fn send_backrun_bundle(&self, bundle: Bundle) -> RpcResult<BundleHash>;
+
+    /// `eth_cancelBundle` is used to prevent a submitted bundle from being included on-chain.
+    #[method(name = "cancelBundle")]
+    async fn cancel_bundle(&self, request: CancelBundle) -> RpcResult<()>;
+
+    /// Handler for: `eth_sendRawTransaction`
+    #[method(name = "sendRawTransaction")]
+    async fn send_raw_transaction(&self, tx: Bytes) -> RpcResult<B256>;
+}
+
+pub struct IngressService<Q: MessageQueue> {
+    mempool_provider: Arc<RootProvider<Optimism>>,
+    simulation_provider: Arc<RootProvider<Optimism>>,
+    raw_tx_forward_provider: Option<Arc<RootProvider<Optimism>>>,
+    tx_submission_method: TxSubmissionMethod,
+    bundle_queue_publisher: BundleQueuePublisher<Q>,
+    audit_channel: mpsc::UnboundedSender<BundleEvent>,
+    send_transaction_default_lifetime_seconds: u64,
+    metrics: Metrics,
+    block_time_milliseconds: u64,
+    meter_bundle_timeout_ms: u64,
+    builder_tx: broadcast::Sender<MeterBundleResponse>,
+    backrun_enabled: bool,
+    builder_backrun_tx: broadcast::Sender<AcceptedBundle>,
+    max_backrun_txs: usize,
+    max_backrun_gas_limit: u64,
+    bundle_cache: Cache<B256, ()>,
+    send_to_builder: bool,
+}
+
+impl<Q: MessageQueue> IngressService<Q> {
+    pub fn new(
+        providers: Providers,
+        queue: Q,
+        audit_channel: mpsc::UnboundedSender<BundleEvent>,
+        builder_tx: broadcast::Sender<MeterBundleResponse>,
+        builder_backrun_tx: broadcast::Sender<AcceptedBundle>,
+        config: Config,
+    ) -> Self {
+        let mempool_provider = Arc::new(providers.mempool);
+        let simulation_provider = Arc::new(providers.simulation);
+        let raw_tx_forward_provider = providers.raw_tx_forward.map(Arc::new);
+        let queue_connection = Arc::new(queue);
+
+        // A TTL cache to deduplicate bundles with the same Bundle ID
+        let bundle_cache =
+            Cache::builder().time_to_live(Duration::from_secs(config.bundle_cache_ttl)).build();
+        Self {
+            mempool_provider,
+            simulation_provider,
+            raw_tx_forward_provider,
+            tx_submission_method: config.tx_submission_method,
+            bundle_queue_publisher: BundleQueuePublisher::new(
+                queue_connection.clone(),
+                config.ingress_topic,
+            ),
+            audit_channel,
+            send_transaction_default_lifetime_seconds: config
+                .send_transaction_default_lifetime_seconds,
+            metrics: Metrics::default(),
+            block_time_milliseconds: config.block_time_milliseconds,
+            meter_bundle_timeout_ms: config.meter_bundle_timeout_ms,
+            builder_tx,
+            backrun_enabled: config.backrun_enabled,
+            builder_backrun_tx,
+            max_backrun_txs: config.max_backrun_txs,
+            max_backrun_gas_limit: config.max_backrun_gas_limit,
+            bundle_cache,
+            send_to_builder: config.send_to_builder,
+        }
+    }
+}
+
+fn validate_backrun_bundle_limits(
+    txs_count: usize,
+    total_gas_limit: u64,
+    max_backrun_txs: usize,
+    max_backrun_gas_limit: u64,
+) -> Result<(), String> {
+    if txs_count < 2 {
+        return Err(
+            "Backrun bundle must have at least 2 transactions (target + backrun)".to_string()
+        );
+    }
+    if txs_count > max_backrun_txs {
+        return Err(format!(
+            "Backrun bundle exceeds max transaction count: {txs_count} > {max_backrun_txs}",
+        ));
+    }
+    if total_gas_limit > max_backrun_gas_limit {
+        return Err(format!(
+            "Backrun bundle exceeds max gas limit: {total_gas_limit} > {max_backrun_gas_limit}",
+        ));
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl<Q: MessageQueue + 'static> IngressApiServer for IngressService<Q> {
+    async fn send_backrun_bundle(&self, bundle: Bundle) -> RpcResult<BundleHash> {
+        if !self.backrun_enabled {
+            return Err(EthApiError::InvalidParams("Backrun bundle submission is disabled".into())
+                .into_rpc_err());
+        }
+
+        let start = Instant::now();
+        let (accepted_bundle, bundle_hash) =
+            self.validate_parse_and_meter_bundle(&bundle, false).await?;
+
+        let total_gas_limit: u64 = accepted_bundle.txs.iter().map(|tx| tx.gas_limit()).sum();
+        validate_backrun_bundle_limits(
+            accepted_bundle.txs.len(),
+            total_gas_limit,
+            self.max_backrun_txs,
+            self.max_backrun_gas_limit,
+        )
+        .map_err(|e| EthApiError::InvalidParams(e).into_rpc_err())?;
+
+        self.metrics.backrun_bundles_received_total.increment(1);
+
+        self.builder_backrun_tx.send(accepted_bundle.clone()).map_err(|e| {
+            EthApiError::InvalidParams(format!("Failed to send backrun bundle: {e}")).into_rpc_err()
+        })?;
+
+        self.send_audit_event(&accepted_bundle, bundle_hash);
+
+        self.metrics.backrun_bundles_sent_duration.record(start.elapsed().as_secs_f64());
+
+        Ok(BundleHash { bundle_hash })
+    }
+
+    async fn send_bundle(&self, bundle: Bundle) -> RpcResult<BundleHash> {
+        let (accepted_bundle, bundle_hash) =
+            self.validate_parse_and_meter_bundle(&bundle, true).await?;
+
+        // Get meter_bundle_response for builder broadcast
+        let meter_bundle_response = accepted_bundle.meter_bundle_response.clone();
+
+        // asynchronously send the meter bundle response to the builder
+        self.builder_tx
+            .send(meter_bundle_response)
+            .map_err(|e| EthApiError::InvalidParams(e.to_string()).into_rpc_err())?;
+
+        // publish the bundle to the queue
+        if let Err(e) = self.bundle_queue_publisher.publish(&accepted_bundle, &bundle_hash).await {
+            warn!(message = "Failed to publish bundle to queue", bundle_hash = %bundle_hash, error = %e);
+            return Err(EthApiError::InvalidParams("Failed to queue bundle".into()).into_rpc_err());
+        }
+
+        info!(
+            message = "queued bundle",
+            bundle_hash = %bundle_hash,
+        );
+
+        // asynchronously send the audit event to the audit channel
+        self.send_audit_event(&accepted_bundle, bundle_hash);
+
+        Ok(BundleHash { bundle_hash })
+    }
+
+    async fn cancel_bundle(&self, _request: CancelBundle) -> RpcResult<()> {
+        warn!(message = "TODO: implement cancel_bundle", method = "cancel_bundle");
+        todo!("implement cancel_bundle")
+    }
+
+    async fn send_raw_transaction(&self, data: Bytes) -> RpcResult<B256> {
+        let start = Instant::now();
+        let transaction = self.get_tx(&data).await?;
+
+        self.metrics.transactions_received.increment(1);
+
+        let send_to_kafka = matches!(
+            self.tx_submission_method,
+            TxSubmissionMethod::Kafka | TxSubmissionMethod::MempoolAndKafka
+        );
+        let send_to_mempool = matches!(
+            self.tx_submission_method,
+            TxSubmissionMethod::Mempool | TxSubmissionMethod::MempoolAndKafka
+        );
+
+        // Forward before metering
+        if let Some(forward_provider) = self.raw_tx_forward_provider.clone() {
+            self.metrics.raw_tx_forwards_total.increment(1);
+            let tx_data = data.clone();
+            let tx_hash = transaction.tx_hash();
+            tokio::spawn(async move {
+                match forward_provider.send_raw_transaction(tx_data.iter().as_slice()).await {
+                    Ok(_) => {
+                        debug!(message = "Forwarded raw tx", hash = %tx_hash);
+                    }
+                    Err(e) => {
+                        warn!(message = "Failed to forward raw tx", hash = %tx_hash, error = %e);
+                    }
+                }
+            });
+        }
+
+        let expiry_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+            + self.send_transaction_default_lifetime_seconds;
+
+        let bundle = Bundle {
+            txs: vec![data.clone()],
+            max_timestamp: Some(expiry_timestamp),
+            reverting_tx_hashes: vec![transaction.tx_hash()],
+            ..Default::default()
+        };
+
+        let parsed_bundle: ParsedBundle = bundle
+            .clone()
+            .try_into()
+            .map_err(|e: String| EthApiError::InvalidParams(e).into_rpc_err())?;
+
+        let bundle_hash = &parsed_bundle.bundle_hash();
+
+        if self.bundle_cache.get(bundle_hash).await.is_some() {
+            debug!(
+                message = "Duplicate bundle detected, skipping Kafka publish",
+                bundle_hash = %bundle_hash,
+                transaction_hash = %transaction.tx_hash(),
+            );
+        } else {
+            self.bundle_cache.insert(*bundle_hash, ()).await;
+            self.metrics.bundles_parsed.increment(1);
+
+            let meter_bundle_response = match self.meter_bundle(&bundle, bundle_hash).await {
+                Ok(response) => {
+                    info!(message = "Metering succeeded for raw transaction", bundle_hash = %bundle_hash, response = ?response);
+                    Some(response)
+                }
+                Err(e) => {
+                    warn!(
+                        bundle_hash = %bundle_hash,
+                        error = %e,
+                        "Metering failed for raw transaction"
+                    );
+                    None
+                }
+            };
+
+            if let Some(meter_info) = meter_bundle_response.as_ref() {
+                self.metrics.successful_simulations.increment(1);
+                if self.send_to_builder {
+                    _ = self.builder_tx.send(meter_info.clone());
+                }
+            } else {
+                self.metrics.failed_simulations.increment(1);
+            }
+
+            let accepted_bundle =
+                AcceptedBundle::new(parsed_bundle, meter_bundle_response.unwrap_or_default());
+
+            if send_to_kafka {
+                if let Err(e) =
+                    self.bundle_queue_publisher.publish(&accepted_bundle, bundle_hash).await
+                {
+                    warn!(message = "Failed to publish Queue::enqueue_bundle", bundle_hash = %bundle_hash, error = %e);
+                }
+
+                self.metrics.sent_to_kafka.increment(1);
+                info!(message="queued singleton bundle", txn_hash=%transaction.tx_hash());
+            }
+
+            if send_to_mempool {
+                let response =
+                    self.mempool_provider.send_raw_transaction(data.iter().as_slice()).await;
+                match response {
+                    Ok(_) => {
+                        self.metrics.sent_to_mempool.increment(1);
+                        debug!(message = "sent transaction to the mempool", hash=%transaction.tx_hash());
+                    }
+                    Err(e) => {
+                        warn!(message = "Failed to send raw transaction to mempool", error = %e);
+                    }
+                }
+            }
+
+            info!(
+                message = "processed transaction",
+                bundle_hash = %bundle_hash,
+                transaction_hash = %transaction.tx_hash(),
+            );
+
+            self.send_audit_event(&accepted_bundle, accepted_bundle.bundle_hash());
+        }
+
+        self.metrics.send_raw_transaction_duration.record(start.elapsed().as_secs_f64());
+
+        Ok(transaction.tx_hash())
+    }
+}
+
+impl<Q: MessageQueue> IngressService<Q> {
+    async fn get_tx(&self, data: &Bytes) -> RpcResult<Recovered<OpTxEnvelope>> {
+        if data.is_empty() {
+            return Err(EthApiError::EmptyRawTransactionData.into_rpc_err());
+        }
+
+        let envelope = OpTxEnvelope::decode_2718_exact(data.iter().as_slice())
+            .map_err(|_| EthApiError::FailedToDecodeSignedTransaction.into_rpc_err())?;
+
+        let transaction = envelope
+            .clone()
+            .try_into_recovered()
+            .map_err(|_| EthApiError::FailedToDecodeSignedTransaction.into_rpc_err())?;
+        Ok(transaction)
+    }
+
+    async fn validate_bundle(&self, bundle: &Bundle) -> RpcResult<()> {
+        let start = Instant::now();
+        if bundle.txs.is_empty() {
+            return Err(EthApiError::InvalidParams("Bundle cannot have empty transactions".into())
+                .into_rpc_err());
+        }
+
+        let mut total_gas = 0u64;
+        let mut tx_hashes = Vec::new();
+        for tx_data in &bundle.txs {
+            let transaction = self.get_tx(tx_data).await?;
+            total_gas = total_gas.saturating_add(transaction.gas_limit());
+            tx_hashes.push(transaction.tx_hash());
+        }
+        validate_bundle(bundle, total_gas, tx_hashes)?;
+
+        self.metrics.validate_bundle_duration.record(start.elapsed().as_secs_f64());
+        Ok(())
+    }
+
+    /// `meter_bundle` is used to determine how long a bundle will take to execute. A bundle that
+    /// is within `block_time_milliseconds` will return the `MeterBundleResponse` that can be passed along
+    /// to the builder.
+    async fn meter_bundle(
+        &self,
+        bundle: &Bundle,
+        bundle_hash: &B256,
+    ) -> RpcResult<MeterBundleResponse> {
+        let start = Instant::now();
+        let timeout_duration = Duration::from_millis(self.meter_bundle_timeout_ms);
+
+        // The future we await has the nested type:
+        // Result<
+        //   RpcResult<MeterBundleResponse>, // 1. The inner operation's result
+        //   tokio::time::error::Elapsed     // 2. The outer timeout's result
+        // >
+        let res: MeterBundleResponse = timeout(
+            timeout_duration,
+            self.simulation_provider.client().request("base_meterBundle", (bundle,)),
+        )
+        .await
+        .map_err(|_| {
+            warn!(message = "Timed out on requesting metering", bundle_hash = %bundle_hash);
+            EthApiError::InvalidParams("Timeout on requesting metering".into()).into_rpc_err()
+        })?
+        .map_err(|e| EthApiError::InvalidParams(e.to_string()).into_rpc_err())?;
+
+        record_histogram(start.elapsed(), "base_meterBundle".to_string());
+
+        // we can save some builder payload building computation by not including bundles
+        // that we know will take longer than the block time to execute
+        let total_execution_time = (res.total_execution_time_us / 1_000) as u64;
+        if total_execution_time > self.block_time_milliseconds {
+            self.metrics.bundles_exceeded_metering_time.increment(1);
+            return Err(
+                EthApiError::InvalidParams("Bundle simulation took too long".into()).into_rpc_err()
+            );
+        }
+        Ok(res)
+    }
+
+    /// Helper method to validate, parse, and meter a bundle
+    async fn validate_parse_and_meter_bundle(
+        &self,
+        bundle: &Bundle,
+        to_meter: bool,
+    ) -> RpcResult<(AcceptedBundle, B256)> {
+        self.validate_bundle(bundle).await?;
+        let parsed_bundle: ParsedBundle = bundle
+            .clone()
+            .try_into()
+            .map_err(|e: String| EthApiError::InvalidParams(e).into_rpc_err())?;
+        let bundle_hash = parsed_bundle.bundle_hash();
+        let meter_bundle_response = if to_meter {
+            self.meter_bundle(bundle, &bundle_hash).await?
+        } else {
+            MeterBundleResponse::default()
+        };
+        let accepted_bundle = AcceptedBundle::new(parsed_bundle, meter_bundle_response.clone());
+        Ok((accepted_bundle, bundle_hash))
+    }
+
+    /// Helper method to send audit event for a bundle
+    fn send_audit_event(&self, accepted_bundle: &AcceptedBundle, bundle_hash: B256) {
+        let audit_event = BundleEvent::Received {
+            bundle_id: *accepted_bundle.uuid(),
+            bundle: Box::new(accepted_bundle.clone()),
+        };
+        if let Err(e) = self.audit_channel.send(audit_event) {
+            warn!(
+                message = "failed to send audit event",
+                bundle_hash = %bundle_hash,
+                error = %e
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, SocketAddr},
+        str::FromStr,
+    };
+
+    use alloy_provider::RootProvider;
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use audit::test_utils::create_test_meter_bundle_response;
+    use jsonrpsee::{
+        http_client::{HttpClient, HttpClientBuilder},
+        server::{ServerBuilder, ServerHandle},
+    };
+    use mockall::mock;
+    use tokio::sync::{broadcast, mpsc};
+    use url::Url;
+    use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+
+    use super::*;
+    use crate::{Config, TxSubmissionMethod, queue::MessageQueue};
+    struct MockQueue;
+
+    #[async_trait]
+    impl MessageQueue for MockQueue {
+        async fn publish(&self, _topic: &str, _key: &str, _payload: &[u8]) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn create_test_config(mock_server: &MockServer) -> Config {
+        Config {
+            address: IpAddr::from([127, 0, 0, 1]),
+            port: 8080,
+            mempool_url: Url::parse("http://localhost:3000").unwrap(),
+            tx_submission_method: TxSubmissionMethod::Mempool,
+            ingress_kafka_properties: String::new(),
+            ingress_topic: String::new(),
+            audit_kafka_properties: String::new(),
+            audit_topic: String::new(),
+            log_level: String::from("info"),
+            log_format: utils::logger::LogFormat::Pretty,
+            send_transaction_default_lifetime_seconds: 300,
+            simulation_rpc: mock_server.uri().parse().unwrap(),
+            metrics_addr: SocketAddr::from(([127, 0, 0, 1], 9002)),
+            block_time_milliseconds: 1000,
+            meter_bundle_timeout_ms: 5000,
+            builder_rpcs: vec![],
+            max_buffered_meter_bundle_responses: 100,
+            max_buffered_backrun_bundles: 100,
+            health_check_addr: SocketAddr::from(([127, 0, 0, 1], 8081)),
+            backrun_enabled: false,
+            raw_tx_forward_rpc: None,
+            chain_id: 11,
+            max_backrun_txs: 5,
+            max_backrun_gas_limit: 5000000,
+            bundle_cache_ttl: 20,
+            send_to_builder: false,
+        }
+    }
+
+    #[allow(dead_code)]
+    async fn setup_rpc_server(mock: MockIngressApi) -> (HttpClient, ServerHandle) {
+        let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+
+        let addr = server.local_addr().unwrap();
+        let handle = server.start(mock.into_rpc());
+
+        let client = HttpClientBuilder::default().build(format!("http://{}", addr)).unwrap();
+
+        (client, handle)
+    }
+
+    #[tokio::test]
+    async fn test_timeout_logic() {
+        let timeout_duration = Duration::from_millis(100);
+
+        // Test a future that takes longer than the timeout
+        let slow_future = async {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            Ok::<MeterBundleResponse, anyhow::Error>(create_test_meter_bundle_response())
+        };
+
+        let result = timeout(timeout_duration, slow_future)
+            .await
+            .map_err(|_| {
+                EthApiError::InvalidParams("Timeout on requesting metering".into()).into_rpc_err()
+            })
+            .map_err(|e| e.to_string());
+
+        assert!(result.is_err());
+        let error_string = format!("{:?}", result.unwrap_err());
+        assert!(error_string.contains("Timeout on requesting metering"));
+    }
+
+    #[tokio::test]
+    async fn test_timeout_logic_success() {
+        let timeout_duration = Duration::from_millis(200);
+
+        // Test a future that completes within the timeout
+        let fast_future = async {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Ok::<MeterBundleResponse, anyhow::Error>(create_test_meter_bundle_response())
+        };
+
+        let result = timeout(timeout_duration, fast_future)
+            .await
+            .map_err(|_| {
+                EthApiError::InvalidParams("Timeout on requesting metering".into()).into_rpc_err()
+            })
+            .map_err(|e| e.to_string());
+
+        assert!(result.is_ok());
+        // we're assumging that `base_meterBundle` will not error hence the second unwrap
+        let res = result.unwrap().unwrap();
+        assert_eq!(res, create_test_meter_bundle_response());
+    }
+
+    // Replicate a failed `meter_bundle` request and instead of returning an error, we return a default `MeterBundleResponse`
+    #[tokio::test]
+    async fn test_meter_bundle_success() {
+        let mock_server = MockServer::start().await;
+
+        // Mock error response from base_meterBundle
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32000,
+                    "message": "Simulation failed"
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = create_test_config(&mock_server);
+
+        let provider: RootProvider<Optimism> =
+            RootProvider::new_http(mock_server.uri().parse().unwrap());
+
+        let providers = Providers {
+            mempool: provider.clone(),
+            simulation: provider.clone(),
+            raw_tx_forward: None,
+        };
+
+        let (audit_tx, _audit_rx) = mpsc::unbounded_channel();
+        let (builder_tx, _builder_rx) = broadcast::channel(1);
+        let (backrun_tx, _backrun_rx) = broadcast::channel(1);
+
+        let service =
+            IngressService::new(providers, MockQueue, audit_tx, builder_tx, backrun_tx, config);
+
+        let bundle = Bundle::default();
+        let bundle_hash = B256::default();
+
+        let result = service.meter_bundle(&bundle, &bundle_hash).await;
+
+        // Test that meter_bundle returns an error, but we handle it gracefully
+        assert!(result.is_err());
+        let response = result.unwrap_or_else(|_| MeterBundleResponse::default());
+        assert_eq!(response, MeterBundleResponse::default());
+    }
+
+    #[tokio::test]
+    async fn test_raw_tx_forward() {
+        let simulation_server = MockServer::start().await;
+        let forward_server = MockServer::start().await;
+
+        // Mock error response from base_meterBundle
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32000,
+                    "message": "Simulation failed"
+                }
+            })))
+            .mount(&simulation_server)
+            .await;
+
+        // Mock forward endpoint - expect exactly 1 call
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": "0x0000000000000000000000000000000000000000000000000000000000000000"
+            })))
+            .expect(1)
+            .mount(&forward_server)
+            .await;
+
+        let mut config = create_test_config(&simulation_server);
+        config.tx_submission_method = TxSubmissionMethod::Kafka; // Skip mempool send
+
+        let providers = Providers {
+            mempool: RootProvider::new_http(simulation_server.uri().parse().unwrap()),
+            simulation: RootProvider::new_http(simulation_server.uri().parse().unwrap()),
+            raw_tx_forward: Some(RootProvider::new_http(forward_server.uri().parse().unwrap())),
+        };
+
+        let (audit_tx, _audit_rx) = mpsc::unbounded_channel();
+        let (builder_tx, _builder_rx) = broadcast::channel(1);
+        let (backrun_tx, _backrun_rx) = broadcast::channel(1);
+
+        let service =
+            IngressService::new(providers, MockQueue, audit_tx, builder_tx, backrun_tx, config);
+
+        // Valid signed transaction bytes
+        let tx_bytes = Bytes::from_str("0x02f86c0d010183072335825208940000000000000000000000000000000000000000872386f26fc1000080c001a0cdb9e4f2f1ba53f9429077e7055e078cf599786e29059cd80c5e0e923bb2c114a01c90e29201e031baf1da66296c3a5c15c200bcb5e6c34da2f05f7d1778f8be07").unwrap();
+
+        let result = service.send_raw_transaction(tx_bytes).await;
+        assert!(result.is_ok());
+
+        // Wait for spawned forward task to complete
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // wiremock automatically verifies expect(1) when forward_server is dropped
+    }
+    mock! {
+        pub IngressApi {}
+
+        #[async_trait]
+        impl IngressApiServer for IngressApi {
+            async fn send_bundle(&self, bundle: Bundle) -> RpcResult<BundleHash>;
+            async fn send_backrun_bundle(&self, bundle: Bundle) -> RpcResult<BundleHash>;
+            async fn cancel_bundle(&self, request: CancelBundle) -> RpcResult<()>;
+            async fn send_raw_transaction(&self, tx: Bytes) -> RpcResult<B256>;
+        }
+    }
+
+    #[test]
+    fn test_validate_backrun_bundle_rejects_invalid() {
+        // Too few transactions (need at least 2: target + backrun)
+        let result = validate_backrun_bundle_limits(1, 21000, 5, 5000000);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("at least 2 transactions"));
+
+        // Exceeds max tx count
+        let result = validate_backrun_bundle_limits(6, 21000, 5, 5000000);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("exceeds max transaction count"));
+
+        // Exceeds max gas limit
+        let result = validate_backrun_bundle_limits(2, 6000000, 5, 5000000);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("exceeds max gas limit"));
+    }
+}

--- a/crates/ingress-rpc/src/validation.rs
+++ b/crates/ingress-rpc/src/validation.rs
@@ -1,0 +1,359 @@
+use std::{
+    collections::HashSet,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use alloy_consensus::private::alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_primitives::{Address, B256, U256};
+use alloy_provider::{Provider, RootProvider};
+use async_trait::async_trait;
+use base_bundles::Bundle;
+use base_reth_rpc_types::{EthApiError, SignError, extract_l1_info_from_tx};
+use jsonrpsee::core::RpcResult;
+use op_alloy_network::Optimism;
+use op_revm::l1block::L1BlockInfo;
+use tokio::time::Instant;
+use tracing::warn;
+
+use crate::metrics::record_histogram;
+
+const MAX_BUNDLE_GAS: u64 = 25_000_000;
+
+/// Account info for a given address
+pub struct AccountInfo {
+    pub balance: U256,
+    pub nonce: u64,
+    pub code_hash: B256,
+}
+
+/// Interface for fetching account info for a given address
+#[async_trait]
+pub trait AccountInfoLookup: Send + Sync {
+    async fn fetch_account_info(&self, address: Address) -> RpcResult<AccountInfo>;
+}
+
+/// Implementation of the `AccountInfoLookup` trait for the `RootProvider`
+#[async_trait]
+impl AccountInfoLookup for RootProvider<Optimism> {
+    async fn fetch_account_info(&self, address: Address) -> RpcResult<AccountInfo> {
+        let start = Instant::now();
+        let account = self
+            .get_account(address)
+            .await
+            .map_err(|_| EthApiError::Signing(SignError::NoAccount))?;
+        record_histogram(start.elapsed(), "eth_getAccount".to_string());
+
+        Ok(AccountInfo {
+            balance: account.balance,
+            nonce: account.nonce,
+            code_hash: account.code_hash,
+        })
+    }
+}
+
+/// Interface for fetching L1 block info for a given block number
+#[async_trait]
+pub trait L1BlockInfoLookup: Send + Sync {
+    async fn fetch_l1_block_info(&self) -> RpcResult<L1BlockInfo>;
+}
+
+/// Implementation of the `L1BlockInfoLookup` trait for the `RootProvider`
+#[async_trait]
+impl L1BlockInfoLookup for RootProvider<Optimism> {
+    async fn fetch_l1_block_info(&self) -> RpcResult<L1BlockInfo> {
+        let start = Instant::now();
+        let block = self
+            .get_block(BlockId::Number(BlockNumberOrTag::Latest))
+            .full()
+            .await
+            .map_err(|e| {
+                warn!(message = "failed to fetch latest block", err = %e);
+                EthApiError::InternalEthError.into_rpc_err()
+            })?
+            .ok_or_else(|| {
+                warn!(message = "empty latest block returned");
+                EthApiError::InternalEthError.into_rpc_err()
+            })?;
+        record_histogram(start.elapsed(), "eth_getBlockByNumber".to_string());
+
+        let txs = block.transactions.clone();
+        let first_tx = txs.first_transaction().ok_or_else(|| {
+            warn!(message = "block contains no transactions");
+            EthApiError::InternalEthError.into_rpc_err()
+        })?;
+
+        Ok(extract_l1_info_from_tx(&first_tx.clone()).map_err(|e| {
+            warn!(message = "failed to extract l1_info from tx", err = %e);
+            EthApiError::InternalEthError.into_rpc_err()
+        })?)
+    }
+}
+
+/// Helper function to validate propeties of a bundle. A bundle is valid if it satisfies the following criteria:
+/// - The bundle's max_timestamp is not more than 1 hour in the future
+/// - The bundle's gas limit is not greater than the maximum allowed gas limit
+/// - The bundle can only contain 3 transactions at once
+/// - Partial transaction dropping is not supported, `dropping_tx_hashes` must be empty
+/// - revert protection is not supported, all transaction hashes must be in `reverting_tx_hashes`
+pub fn validate_bundle(bundle: &Bundle, bundle_gas: u64, tx_hashes: Vec<B256>) -> RpcResult<()> {
+    // Don't allow bundles to be submitted over 1 hour into the future
+    // TODO: make the window configurable
+    let valid_timestamp_window = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+        + Duration::from_secs(3600).as_secs();
+    if let Some(max_timestamp) = bundle.max_timestamp
+        && max_timestamp > valid_timestamp_window
+    {
+        return Err(EthApiError::InvalidParams(
+            "Bundle cannot be more than 1 hour in the future".into(),
+        )
+        .into_rpc_err());
+    }
+
+    // Check max gas limit for the entire bundle
+    if bundle_gas > MAX_BUNDLE_GAS {
+        return Err(EthApiError::InvalidParams("Bundle gas limit exceeds maximum allowed".into())
+            .into_rpc_err());
+    }
+
+    // Can only provide 3 transactions at once
+    if bundle.txs.len() > 3 {
+        return Err(EthApiError::InvalidParams("Bundle can only contain 3 transactions".into())
+            .into_rpc_err());
+    }
+
+    // Partial transaction dropping is not supported, `dropping_tx_hashes` must be empty
+    if !bundle.dropping_tx_hashes.is_empty() {
+        return Err(EthApiError::InvalidParams(
+            "Partial transaction dropping is not supported".into(),
+        )
+        .into_rpc_err());
+    }
+
+    // revert protection: all transaction hashes must be in `reverting_tx_hashes`
+    let reverting_tx_hashes_set: HashSet<_> = bundle.reverting_tx_hashes.iter().collect();
+    let tx_hashes_set: HashSet<_> = tx_hashes.iter().collect();
+    if reverting_tx_hashes_set != tx_hashes_set {
+        return Err(EthApiError::InvalidParams(
+            "Revert protection is not supported. reverting_tx_hashes must include all hashes"
+                .into(),
+        )
+        .into_rpc_err());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use alloy_consensus::{SignableTransaction, TxEip1559, transaction::SignerRecoverable};
+    use alloy_primitives::{Bytes, bytes};
+    use alloy_signer_local::PrivateKeySigner;
+    use op_alloy_consensus::OpTxEnvelope;
+    use op_alloy_network::{TxSignerSync, eip2718::Encodable2718};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_err_bundle_max_timestamp_too_far_in_the_future() {
+        let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let too_far_in_the_future = current_time + 3601;
+        let bundle = Bundle {
+            txs: vec![],
+            max_timestamp: Some(too_far_in_the_future),
+            ..Default::default()
+        };
+        assert_eq!(
+            validate_bundle(&bundle, 0, vec![]),
+            Err(EthApiError::InvalidParams(
+                "Bundle cannot be more than 1 hour in the future".into()
+            )
+            .into_rpc_err())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_err_bundle_max_gas_limit_too_high() {
+        let signer = PrivateKeySigner::random();
+        let mut encoded_txs = vec![];
+        let mut tx_hashes = vec![];
+
+        // Create transactions that collectively exceed MAX_BUNDLE_GAS (25M)
+        // Each transaction uses 4M gas, so 8 transactions = 32M gas > 25M limit
+        let gas = 4_000_000;
+        let mut total_gas = 0u64;
+        for _ in 0..8 {
+            let mut tx = TxEip1559 {
+                chain_id: 1,
+                nonce: 0,
+                gas_limit: gas,
+                max_fee_per_gas: 200000u128,
+                max_priority_fee_per_gas: 100000u128,
+                to: Address::random().into(),
+                value: U256::from(1000000u128),
+                access_list: Default::default(),
+                input: bytes!("").clone(),
+            };
+            total_gas = total_gas.saturating_add(gas);
+
+            let signature = signer.sign_transaction_sync(&mut tx).unwrap();
+            let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
+            let tx_hash = envelope.clone().try_into_recovered().unwrap().tx_hash();
+            tx_hashes.push(tx_hash);
+
+            // Encode the transaction
+            let mut encoded = vec![];
+            envelope.encode_2718(&mut encoded);
+            encoded_txs.push(Bytes::from(encoded));
+        }
+
+        let bundle = Bundle {
+            txs: encoded_txs,
+            block_number: 0,
+            min_timestamp: None,
+            max_timestamp: None,
+            reverting_tx_hashes: vec![],
+            ..Default::default()
+        };
+
+        // Test should fail due to exceeding gas limit
+        let result = validate_bundle(&bundle, total_gas, tx_hashes);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            let error_message = format!("{e:?}");
+            assert!(error_message.contains("Bundle gas limit exceeds maximum allowed"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_err_bundle_too_many_transactions() {
+        let signer = PrivateKeySigner::random();
+        let mut encoded_txs = vec![];
+        let mut tx_hashes = vec![];
+
+        let gas = 4_000_000;
+        let mut total_gas = 0u64;
+        for _ in 0..4 {
+            let mut tx = TxEip1559 {
+                chain_id: 1,
+                nonce: 0,
+                gas_limit: gas,
+                max_fee_per_gas: 200000u128,
+                max_priority_fee_per_gas: 100000u128,
+                to: Address::random().into(),
+                value: U256::from(1000000u128),
+                access_list: Default::default(),
+                input: bytes!("").clone(),
+            };
+            total_gas = total_gas.saturating_add(gas);
+
+            let signature = signer.sign_transaction_sync(&mut tx).unwrap();
+            let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
+            let tx_hash = envelope.clone().try_into_recovered().unwrap().tx_hash();
+            tx_hashes.push(tx_hash);
+
+            // Encode the transaction
+            let mut encoded = vec![];
+            envelope.encode_2718(&mut encoded);
+            encoded_txs.push(Bytes::from(encoded));
+        }
+
+        let bundle = Bundle {
+            txs: encoded_txs,
+            block_number: 0,
+            min_timestamp: None,
+            max_timestamp: None,
+            reverting_tx_hashes: vec![],
+            ..Default::default()
+        };
+
+        // Test should fail due to exceeding gas limit
+        let result = validate_bundle(&bundle, total_gas, tx_hashes);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            let error_message = format!("{e:?}");
+            assert!(error_message.contains("Bundle can only contain 3 transactions"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_err_bundle_partial_transaction_dropping_not_supported() {
+        let bundle =
+            Bundle { txs: vec![], dropping_tx_hashes: vec![B256::random()], ..Default::default() };
+        assert_eq!(
+            validate_bundle(&bundle, 0, vec![]),
+            Err(EthApiError::InvalidParams("Partial transaction dropping is not supported".into())
+                .into_rpc_err())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_err_bundle_not_all_tx_hashes_in_reverting_tx_hashes() {
+        let signer = PrivateKeySigner::random();
+        let mut encoded_txs = vec![];
+        let mut tx_hashes = vec![];
+
+        let gas = 4_000_000;
+        let mut total_gas = 0u64;
+        for _ in 0..4 {
+            let mut tx = TxEip1559 {
+                chain_id: 1,
+                nonce: 0,
+                gas_limit: gas,
+                max_fee_per_gas: 200000u128,
+                max_priority_fee_per_gas: 100000u128,
+                to: Address::random().into(),
+                value: U256::from(1000000u128),
+                access_list: Default::default(),
+                input: bytes!("").clone(),
+            };
+            total_gas = total_gas.saturating_add(gas);
+
+            let signature = signer.sign_transaction_sync(&mut tx).unwrap();
+            let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
+            let tx_hash = envelope.clone().try_into_recovered().unwrap().tx_hash();
+            tx_hashes.push(tx_hash);
+
+            // Encode the transaction
+            let mut encoded = vec![];
+            envelope.encode_2718(&mut encoded);
+            encoded_txs.push(Bytes::from(encoded));
+        }
+
+        let bundle = Bundle {
+            txs: encoded_txs,
+            block_number: 0,
+            min_timestamp: None,
+            max_timestamp: None,
+            reverting_tx_hashes: tx_hashes[..2].to_vec(),
+            ..Default::default()
+        };
+
+        // Test should fail due to exceeding gas limit
+        let result = validate_bundle(&bundle, total_gas, tx_hashes);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            let error_message = format!("{e:?}");
+            assert!(error_message.contains("Bundle can only contain 3 transactions"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_decode_tx_rejects_empty_bytes() {
+        // Test that empty bytes fail to decode
+        use op_alloy_network::eip2718::Decodable2718;
+        let empty_bytes = Bytes::new();
+        let result = OpTxEnvelope::decode_2718(&mut empty_bytes.as_ref());
+        assert!(result.is_err(), "Empty bytes should fail decoding");
+    }
+
+    #[tokio::test]
+    async fn test_decode_tx_rejects_invalid_bytes() {
+        // Test that malformed bytes fail to decode
+        use op_alloy_network::eip2718::Decodable2718;
+        let invalid_bytes = Bytes::from(vec![0x01, 0x02, 0x03]);
+        let result = OpTxEnvelope::decode_2718(&mut invalid_bytes.as_ref());
+        assert!(result.is_err(), "Invalid bytes should fail decoding");
+    }
+}

--- a/crates/mempool-rebroadcaster/Cargo.toml
+++ b/crates/mempool-rebroadcaster/Cargo.toml
@@ -14,7 +14,8 @@ path = "src/lib.rs"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-tokio = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "std", "json", "env-filter"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 # alloy
 alloy-primitives.workspace = true
@@ -23,4 +24,5 @@ alloy-rpc-types = { workspace = true, features = ["txpool"] }
 alloy-rpc-types-eth.workspace = true
 alloy-consensus.workspace = true
 alloy-trie.workspace = true
-alloy-provider = { workspace = true, features = ["txpool-api"] }
+alloy-provider = { workspace = true, features = ["txpool-api", "reqwest"] }
+

--- a/crates/sidecrush/Cargo.toml
+++ b/crates/sidecrush/Cargo.toml
@@ -14,16 +14,14 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 cadence = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tracing = { workspace = true }
-tokio = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "std", "json"] }
 
 # Ethereum client deps (will be used for header fetching)
-alloy-provider = { workspace = true }
-alloy-transport-http = { workspace = true }
-alloy-rpc-types-eth = { workspace = true }
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+alloy-rpc-types-eth = { workspace = true }
+alloy-transport-http = { workspace = true }
 
-[dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-tracing = { workspace = true }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "utils"
+description = "Shared utility functions for logging, metrics, and config parsing"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tracing = { workspace = true, features = ["std"] }
+alloy-rpc-types = { workspace = true, features = ["eth"] }
+metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
+tracing-subscriber = { workspace = true, features = ["std", "fmt", "ansi", "env-filter", "json"] }
+
+[dev-dependencies]
+serde_json = { workspace = true, features = ["std"] }

--- a/crates/utils/README.md
+++ b/crates/utils/README.md
@@ -1,0 +1,3 @@
+# `utils`
+
+Shared utility functions for `base/infra` services — logging, metrics, and config parsing.

--- a/crates/utils/src/kafka.rs
+++ b/crates/utils/src/kafka.rs
@@ -1,0 +1,21 @@
+use std::{collections::HashMap, fs};
+
+pub fn load_kafka_config_from_file(
+    properties_file_path: &str,
+) -> Result<HashMap<String, String>, std::io::Error> {
+    let kafka_properties = fs::read_to_string(properties_file_path)?;
+
+    let mut config = HashMap::new();
+
+    for line in kafka_properties.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            config.insert(key.trim().to_string(), value.trim().to_string());
+        }
+    }
+
+    Ok(config)
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,0 +1,11 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/infra/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![allow(missing_docs)]
+
+use alloy_rpc_types as _;
+
+pub mod kafka;
+pub mod logger;
+pub mod metrics;

--- a/crates/utils/src/logger.rs
+++ b/crates/utils/src/logger.rs
@@ -1,0 +1,63 @@
+use std::str::FromStr;
+
+use tracing::warn;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogFormat {
+    Pretty,
+    Json,
+    Compact,
+}
+
+impl FromStr for LogFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "json" => Ok(Self::Json),
+            "compact" => Ok(Self::Compact),
+            "pretty" => Ok(Self::Pretty),
+            _ => {
+                warn!("Invalid log format '{}', defaulting to 'pretty'", s);
+                Ok(Self::Pretty)
+            }
+        }
+    }
+}
+
+pub fn init_logger(log_level: &str) {
+    init_logger_with_format(log_level, LogFormat::Pretty);
+}
+
+pub fn init_logger_with_format(log_level: &str, format: LogFormat) {
+    let level = match log_level.to_lowercase().as_str() {
+        "trace" => tracing::Level::TRACE,
+        "debug" => tracing::Level::DEBUG,
+        "info" => tracing::Level::INFO,
+        "warn" => tracing::Level::WARN,
+        "error" => tracing::Level::ERROR,
+        _ => {
+            warn!("Invalid log level '{}', defaulting to 'info'", log_level);
+            tracing::Level::INFO
+        }
+    };
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(level.to_string()));
+
+    match format {
+        LogFormat::Json => {
+            tracing_subscriber::registry()
+                .with(env_filter)
+                .with(fmt::layer().json().flatten_event(true).with_current_span(true))
+                .init();
+        }
+        LogFormat::Compact => {
+            tracing_subscriber::registry().with(env_filter).with(fmt::layer().compact()).init();
+        }
+        LogFormat::Pretty => {
+            tracing_subscriber::registry().with(env_filter).with(fmt::layer().pretty()).init();
+        }
+    }
+}

--- a/crates/utils/src/metrics.rs
+++ b/crates/utils/src/metrics.rs
@@ -1,0 +1,10 @@
+use std::net::SocketAddr;
+
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+pub fn init_prometheus_exporter(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
+    PrometheusBuilder::new()
+        .with_http_listener(addr)
+        .install()
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+}

--- a/deny.toml
+++ b/deny.toml
@@ -48,10 +48,37 @@ skip = [
     "foldhash",
     "lru",
 
+    # AWS SDK transitive dependencies
+    "aws-smithy-http",
+    "aws-smithy-json",
+
+    # HTTP ecosystem (hyper 0.14 vs 1.x transition)
+    "h2",
+    "http",
+    "http-body",
+    "hyper",
+    "hyper-rustls",
+
+    # TLS/crypto ecosystem
+    "rustls",
+    "rustls-webpki",
+    "tokio-rustls",
+
+    # macOS security framework
+    "core-foundation",
+    "security-framework",
+    "openssl-probe",
+
     # Random number generation
     "rand",
     "rand_chacha",
     "rand_core",
+
+    # Networking
+    "socket2",
+
+    # OP Stack crates (reth uses older versions)
+    "op-alloy-consensus",
 
     # Proc-macro / derive ecosystem (alloy-tx-macros vs ratatui/instability)
     "darling",

--- a/deny.toml
+++ b/deny.toml
@@ -79,6 +79,11 @@ skip = [
 
     # OP Stack crates (reth uses older versions)
     "op-alloy-consensus",
+    "op-alloy-rpc-types",
+
+    # thiserror 1.x vs 2.x transition
+    "thiserror",
+    "thiserror-impl",
 
     # Proc-macro / derive ecosystem (alloy-tx-macros vs ratatui/instability)
     "darling",

--- a/justfile
+++ b/justfile
@@ -105,3 +105,7 @@ run-mempool-rebroadcaster:
 # Run tips audit service
 run-audit:
     cargo run --bin audit
+
+# Run tips ingress RPC service
+run-ingress-rpc:
+    cargo run --bin ingress-rpc

--- a/justfile
+++ b/justfile
@@ -102,6 +102,6 @@ docker-image:
 run-mempool-rebroadcaster:
     cargo run --bin mempool-rebroadcaster -- --geth-mempool-endpoint {{env_var("GETH_MEMPOOL_ENDPOINT")}} --reth-mempool-endpoint {{env_var("RETH_MEMPOOL_ENDPOINT")}}
 
-# Run basectl with specified config (mainnet, sepolia, devnet, or path)
-basectl config="mainnet":
-    cargo run -p basectl --release -- -c {{config}}
+# Run tips audit service
+run-audit:
+    cargo run --bin audit


### PR DESCRIPTION
We move the `tips-ingress-rpc` service and associated crates from `base/tips` to `base/infra`. We also remove dependence on account abstraction code from the `tips-account-abstraction-core` crate.

Fixes #24 