### PR TITLE
fix(basectl): Silent Panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
  "url",
 ]
 

--- a/crates/basectl/Cargo.toml
+++ b/crates/basectl/Cargo.toml
@@ -28,3 +28,4 @@ alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-contract = { workspace = true }
 arboard = { workspace = true }
+tracing = { workspace = true }

--- a/crates/basectl/src/app/core.rs
+++ b/crates/basectl/src/app/core.rs
@@ -45,6 +45,7 @@ impl App {
         loop {
             self.resources.da.poll();
             self.resources.flash.poll();
+            self.resources.toasts.poll();
             self.resources.poll_sys_config();
 
             let action = current_view.tick(&mut self.resources);
@@ -61,6 +62,7 @@ impl App {
                     self.resources.chain_name(),
                     current_view.keybindings(),
                 );
+                self.resources.toasts.render(frame, frame.area());
             })?;
 
             if event::poll(EVENT_POLL_TIMEOUT)?

--- a/crates/basectl/src/app/resources.rs
+++ b/crates/basectl/src/app/resources.rs
@@ -8,6 +8,7 @@ use crate::{
     config::ChainConfig,
     l1_client::FullSystemConfig,
     rpc::{BacklogFetchResult, BlobSubmission, BlockDaInfo, TimestampedFlashblock},
+    tui::ToastState,
 };
 
 const MAX_FLASHBLOCKS: usize = 100;
@@ -17,6 +18,7 @@ pub struct Resources {
     pub config: ChainConfig,
     pub da: DaState,
     pub flash: FlashState,
+    pub toasts: ToastState,
     pub system_config: Option<FullSystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<FullSystemConfig>>,
 }
@@ -53,6 +55,7 @@ impl Resources {
             config,
             da: DaState::new(has_op_node),
             flash: FlashState::new(),
+            toasts: ToastState::new(),
             system_config: None,
             sys_config_rx: None,
         }

--- a/crates/basectl/src/app/runner.rs
+++ b/crates/basectl/src/app/runner.rs
@@ -13,6 +13,7 @@ use crate::{
         fetch_initial_backlog_with_progress, fetch_sync_status, run_block_fetcher,
         run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_batcher_watcher,
     },
+    tui::Toast,
 };
 
 pub async fn run_app(config: ChainConfig) -> Result<()> {
@@ -41,16 +42,19 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
     let (block_req_tx, block_req_rx) = mpsc::channel::<u64>(100);
     let (block_res_tx, block_res_rx) = mpsc::channel::<BlockDaInfo>(100);
     let (blob_tx, blob_rx) = mpsc::channel::<BlobSubmission>(100);
+    let (toast_tx, toast_rx) = mpsc::channel::<Toast>(50);
 
     resources.flash.set_channel(fb_rx);
     resources.da.set_channels(da_fb_rx, sync_rx, backlog_rx, block_req_tx, block_res_rx, blob_rx);
+    resources.toasts.set_channel(toast_rx);
 
     let ws_url = config.flashblocks_ws.to_string();
     let ws_url2 = config.flashblocks_ws.to_string();
 
-    tokio::spawn(run_flashblock_ws_timestamped(ws_url, fb_tx));
+    let toast_tx_clone = toast_tx.clone();
+    tokio::spawn(run_flashblock_ws_timestamped(ws_url, fb_tx, Some(toast_tx_clone)));
 
-    tokio::spawn(run_flashblock_ws(ws_url2, da_fb_tx));
+    tokio::spawn(run_flashblock_ws(ws_url2, da_fb_tx, Some(toast_tx)));
 
     let rpc_url = config.rpc.to_string();
     tokio::spawn(async move {

--- a/crates/basectl/src/app/runner.rs
+++ b/crates/basectl/src/app/runner.rs
@@ -48,13 +48,9 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
     let ws_url = config.flashblocks_ws.to_string();
     let ws_url2 = config.flashblocks_ws.to_string();
 
-    tokio::spawn(async move {
-        let _ = run_flashblock_ws_timestamped(ws_url, fb_tx).await;
-    });
+    tokio::spawn(run_flashblock_ws_timestamped(ws_url, fb_tx));
 
-    tokio::spawn(async move {
-        let _ = run_flashblock_ws(ws_url2, da_fb_tx).await;
-    });
+    tokio::spawn(run_flashblock_ws(ws_url2, da_fb_tx));
 
     let rpc_url = config.rpc.to_string();
     tokio::spawn(async move {

--- a/crates/basectl/src/rpc.rs
+++ b/crates/basectl/src/rpc.rs
@@ -10,12 +10,18 @@ use futures_util::{StreamExt, stream};
 use serde::Deserialize;
 use tokio::sync::mpsc;
 use tokio_tungstenite::connect_async;
+use tracing::warn;
 
 const CONCURRENT_BLOCK_FETCHES: usize = 16;
 
 use crate::{config::ChainConfig, l1_client::fetch_system_config_params};
 
 const DEFAULT_ELASTICITY: u64 = 6;
+
+/// Initial delay before reconnecting after a WebSocket failure
+const WS_RECONNECT_INITIAL_DELAY: Duration = Duration::from_secs(1);
+/// Maximum delay between reconnection attempts
+const WS_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct L2BlockRef {
@@ -39,21 +45,44 @@ pub async fn fetch_sync_status(op_node_rpc: &str) -> Result<SyncStatus> {
     Ok(status)
 }
 
-pub async fn run_flashblock_ws(url: String, tx: mpsc::Sender<Flashblock>) -> Result<()> {
-    let (ws_stream, _) = connect_async(&url).await?;
-    let (_, mut read) = ws_stream.split();
+pub async fn run_flashblock_ws(url: String, tx: mpsc::Sender<Flashblock>) {
+    let mut delay = WS_RECONNECT_INITIAL_DELAY;
 
-    while let Some(msg) = read.next().await {
-        let msg = msg?;
-        if !msg.is_binary() && !msg.is_text() {
-            continue;
+    loop {
+        match connect_async(&url).await {
+            Ok((ws_stream, _)) => {
+                delay = WS_RECONNECT_INITIAL_DELAY; // Reset delay on successful connect
+                let (_, mut read) = ws_stream.split();
+
+                while let Some(msg) = read.next().await {
+                    let msg = match msg {
+                        Ok(m) => m,
+                        Err(e) => {
+                            warn!("Flashblock WebSocket connection error: {e}");
+                            break; // Connection error, reconnect
+                        }
+                    };
+                    if !msg.is_binary() && !msg.is_text() {
+                        continue;
+                    }
+                    let fb = match Flashblock::try_decode_message(msg.into_data()) {
+                        Ok(fb) => fb,
+                        Err(_) => continue, // Skip malformed messages
+                    };
+                    if tx.send(fb).await.is_err() {
+                        return; // Channel closed, exit completely
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Failed to connect to flashblock WebSocket: {e}");
+            }
         }
-        let fb = Flashblock::try_decode_message(msg.into_data())?;
-        if tx.send(fb).await.is_err() {
-            break;
-        }
+
+        // Wait before reconnecting with exponential backoff
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(WS_RECONNECT_MAX_DELAY);
     }
-    Ok(())
 }
 
 #[derive(Debug)]
@@ -62,26 +91,46 @@ pub struct TimestampedFlashblock {
     pub received_at: chrono::DateTime<chrono::Local>,
 }
 
-pub async fn run_flashblock_ws_timestamped(
-    url: String,
-    tx: mpsc::Sender<TimestampedFlashblock>,
-) -> Result<()> {
-    let (ws_stream, _) = connect_async(&url).await?;
-    let (_, mut read) = ws_stream.split();
+pub async fn run_flashblock_ws_timestamped(url: String, tx: mpsc::Sender<TimestampedFlashblock>) {
+    let mut delay = WS_RECONNECT_INITIAL_DELAY;
 
-    while let Some(msg) = read.next().await {
-        let msg = msg?;
-        if !msg.is_binary() && !msg.is_text() {
-            continue;
+    loop {
+        match connect_async(&url).await {
+            Ok((ws_stream, _)) => {
+                delay = WS_RECONNECT_INITIAL_DELAY; // Reset delay on successful connect
+                let (_, mut read) = ws_stream.split();
+
+                while let Some(msg) = read.next().await {
+                    let msg = match msg {
+                        Ok(m) => m,
+                        Err(e) => {
+                            warn!("Flashblock WebSocket connection error: {e}");
+                            break; // Connection error, reconnect
+                        }
+                    };
+                    if !msg.is_binary() && !msg.is_text() {
+                        continue;
+                    }
+                    let fb = match Flashblock::try_decode_message(msg.into_data()) {
+                        Ok(fb) => fb,
+                        Err(_) => continue, // Skip malformed messages
+                    };
+                    let timestamped =
+                        TimestampedFlashblock { flashblock: fb, received_at: chrono::Local::now() };
+                    if tx.send(timestamped).await.is_err() {
+                        return; // Channel closed, exit completely
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Failed to connect to flashblock WebSocket: {e}");
+            }
         }
-        let fb = Flashblock::try_decode_message(msg.into_data())?;
-        let timestamped =
-            TimestampedFlashblock { flashblock: fb, received_at: chrono::Local::now() };
-        if tx.send(timestamped).await.is_err() {
-            break;
-        }
+
+        // Wait before reconnecting with exponential backoff
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(WS_RECONNECT_MAX_DELAY);
     }
-    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/crates/basectl/src/tui/mod.rs
+++ b/crates/basectl/src/tui/mod.rs
@@ -1,7 +1,9 @@
 pub mod app_frame;
 pub mod keybinding;
 pub mod terminal;
+pub mod toast;
 
 pub use app_frame::{AppFrame, AppLayout};
 pub use keybinding::Keybinding;
 pub use terminal::{restore_terminal, setup_terminal};
+pub use toast::{Toast, ToastLevel, ToastState};

--- a/crates/basectl/src/tui/toast.rs
+++ b/crates/basectl/src/tui/toast.rs
@@ -1,0 +1,143 @@
+use std::time::{Duration, Instant};
+
+use ratatui::{
+    layout::{Alignment, Rect},
+    prelude::*,
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
+use tokio::sync::mpsc;
+
+/// Duration to display a toast notification
+const TOAST_DURATION: Duration = Duration::from_secs(5);
+
+/// Toast severity level
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToastLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+impl ToastLevel {
+    const fn color(self) -> Color {
+        match self {
+            Self::Info => Color::Cyan,
+            Self::Warning => Color::Yellow,
+            Self::Error => Color::Red,
+        }
+    }
+
+    const fn icon(self) -> &'static str {
+        match self {
+            Self::Info => "ℹ",
+            Self::Warning => "⚠",
+            Self::Error => "✗",
+        }
+    }
+}
+
+/// A toast notification message
+#[derive(Debug, Clone)]
+pub struct Toast {
+    pub level: ToastLevel,
+    pub message: String,
+    pub created_at: Instant,
+}
+
+impl Toast {
+    pub fn new(level: ToastLevel, message: impl Into<String>) -> Self {
+        Self { level, message: message.into(), created_at: Instant::now() }
+    }
+
+    pub fn info(message: impl Into<String>) -> Self {
+        Self::new(ToastLevel::Info, message)
+    }
+
+    pub fn warning(message: impl Into<String>) -> Self {
+        Self::new(ToastLevel::Warning, message)
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self::new(ToastLevel::Error, message)
+    }
+
+    fn is_expired(&self) -> bool {
+        self.created_at.elapsed() > TOAST_DURATION
+    }
+}
+
+/// State for managing toast notifications
+#[derive(Debug)]
+pub struct ToastState {
+    toasts: Vec<Toast>,
+    rx: Option<mpsc::Receiver<Toast>>,
+}
+
+impl Default for ToastState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToastState {
+    pub const fn new() -> Self {
+        Self { toasts: Vec::new(), rx: None }
+    }
+
+    pub fn set_channel(&mut self, rx: mpsc::Receiver<Toast>) {
+        self.rx = Some(rx);
+    }
+
+    /// Poll for new toasts and remove expired ones
+    pub fn poll(&mut self) {
+        // Receive new toasts
+        if let Some(ref mut rx) = self.rx {
+            while let Ok(toast) = rx.try_recv() {
+                self.toasts.push(toast);
+            }
+        }
+
+        // Remove expired toasts
+        self.toasts.retain(|t| !t.is_expired());
+    }
+
+    /// Get the current active toast (most recent)
+    pub fn current(&self) -> Option<&Toast> {
+        self.toasts.last()
+    }
+
+    /// Render toasts in the bottom-right corner of the given area
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        let Some(toast) = self.current() else {
+            return;
+        };
+
+        let toast_width = (toast.message.len() as u16 + 6).clamp(20, 50);
+        let toast_height = 3;
+
+        // Position in bottom-right corner with padding
+        let x = area.x + area.width.saturating_sub(toast_width + 2);
+        let y = area.y + area.height.saturating_sub(toast_height + 1);
+
+        let toast_area = Rect::new(x, y, toast_width, toast_height);
+
+        // Clear the area behind the toast
+        frame.render_widget(Clear, toast_area);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(toast.level.color()))
+            .title(format!(" {} ", toast.level.icon()))
+            .title_style(Style::default().fg(toast.level.color()));
+
+        let inner = block.inner(toast_area);
+        frame.render_widget(block, toast_area);
+
+        let content = Paragraph::new(toast.message.as_str())
+            .style(Style::default().fg(Color::White))
+            .wrap(Wrap { trim: true })
+            .alignment(Alignment::Left);
+
+        frame.render_widget(content, inner);
+    }
+}


### PR DESCRIPTION
## Summary

basectl would silently stop updating after running for a while. Investigation
found that when the flashblock WebSocket connection dropped (network hiccup,
server restart, timeout), the task would exit and never reconnect. The UI
kept running but no new data flowed in.

Changes:
- WebSocket functions now loop forever, reconnecting on any failure
- Exponential backoff: 1s -> 2s -> 4s -> ... -> 30s max between retries
- Backoff resets on successful connection
- Malformed messages are skipped instead of crashing the task
- Tasks only exit when the channel closes (app shutdown)

Also fixes DA backlog calculation to use full encoded transaction size
instead of just calldata, matching how flashblocks calculate DA bytes.