### PR TITLE
feat(basectl): add flashtest functional test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
+ "k256",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -519,6 +520,7 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
 dependencies = [
+ "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
@@ -537,12 +539,14 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
 dependencies = [
+ "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck",
  "macro-string",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.114",
  "syn-solidity",
 ]
@@ -720,7 +724,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -979,6 +983,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base-bundles"
+version = "0.0.0"
+source = "git+https://github.com/base/base.git?rev=720f6e1a#720f6e1a73faabc938402b0cb617d3960db742d4"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-serde",
+ "op-alloy-consensus 0.23.1",
+ "op-alloy-flz",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "base-flashtypes"
 version = "0.0.0"
 source = "git+https://github.com/base/base.git?rev=720f6e1a#720f6e1a73faabc938402b0cb617d3960db742d4"
@@ -1026,6 +1045,7 @@ dependencies = [
  "basectl-cli",
  "chrono",
  "clap",
+ "flashtest",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1046,6 +1066,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "dirs",
+ "flashtest",
  "futures-util",
  "gobrr",
  "ratatui",
@@ -1784,7 +1805,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1927,7 +1948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1935,6 +1956,16 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
 
 [[package]]
 name = "fastrand"
@@ -2019,6 +2050,38 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flashtest"
+version = "0.0.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-macro",
+ "alloy-sol-types",
+ "base-bundles",
+ "base-flashtypes",
+ "brotli",
+ "eyre",
+ "futures-util",
+ "hex",
+ "op-alloy-network",
+ "op-alloy-rpc-types",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2686,6 +2749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,7 +3128,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3250,6 +3319,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-alloy-consensus"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-flz"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
+
+[[package]]
 name = "op-alloy-network"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3261,7 +3352,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.22.4",
  "op-alloy-rpc-types",
 ]
 
@@ -3278,7 +3369,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.22.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3687,7 +3778,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4048,7 +4139,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4663,7 +4754,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5190,6 +5281,7 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,15 @@ op-alloy-consensus = { version = "0.22.0", default-features = false }
 op-alloy-network = { version = "0.22.0" }
 
 
+# misc
+brotli = "8.0"
+eyre = "0.6"
+hex = "0.4"
+alloy-sol-macro = { version = "1.5.2" }
+
 # base
+base-bundles = { git = "https://github.com/base/base.git", rev = "720f6e1a" }
 base-flashtypes = { git = "https://github.com/base/base.git", rev = "720f6e1a" }
 basectl-cli = { path = "crates/basectl" }
+flashtest = { path = "crates/flashtest" }
 gobrr = { path = "crates/gobrr" }

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -14,6 +14,7 @@ path = "main.rs"
 [dependencies]
 basectl-cli = { workspace = true }
 chrono = { workspace = true }
+flashtest = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/basectl/Cargo.toml
+++ b/crates/basectl/Cargo.toml
@@ -27,5 +27,6 @@ alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-contract = { workspace = true }
 arboard = { workspace = true }
+flashtest = { workspace = true }
 gobrr = { workspace = true }
 tracing = { workspace = true }

--- a/crates/basectl/src/app/mod.rs
+++ b/crates/basectl/src/app/mod.rs
@@ -11,5 +11,7 @@ pub use core::App;
 pub use action::Action;
 pub use resources::{DaState, FlashState, Resources};
 pub use router::{Router, ViewId};
-pub use runner::{run_app_with_view, run_loadtest_logs, run_loadtest_tui};
+pub use runner::{
+    run_app_with_view, run_flashtest_logs, run_flashtest_tui, run_loadtest_logs, run_loadtest_tui,
+};
 pub use view::View;

--- a/crates/basectl/src/app/resources.rs
+++ b/crates/basectl/src/app/resources.rs
@@ -20,6 +20,7 @@ pub struct Resources {
     pub system_config: Option<FullSystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<FullSystemConfig>>,
     pub loadtest: Option<gobrr::LoadTestState>,
+    pub flashtest: Option<flashtest::FlashTestState>,
 }
 
 #[derive(Debug)]
@@ -57,6 +58,7 @@ impl Resources {
             system_config: None,
             sys_config_rx: None,
             loadtest: None,
+            flashtest: None,
         }
     }
 

--- a/crates/basectl/src/app/router.rs
+++ b/crates/basectl/src/app/router.rs
@@ -6,6 +6,7 @@ pub enum ViewId {
     Flashblocks,
     Config,
     LoadTest,
+    FlashTest,
 }
 
 #[derive(Debug)]

--- a/crates/basectl/src/app/views/factory.rs
+++ b/crates/basectl/src/app/views/factory.rs
@@ -1,5 +1,6 @@
 use super::{
-    CommandCenterView, ConfigView, DaMonitorView, FlashblocksView, HomeView, LoadTestView,
+    CommandCenterView, ConfigView, DaMonitorView, FlashTestView, FlashblocksView, HomeView,
+    LoadTestView,
 };
 use crate::app::{View, ViewId};
 
@@ -11,5 +12,6 @@ pub fn create_view(view_id: ViewId) -> Box<dyn View> {
         ViewId::Flashblocks => Box::new(FlashblocksView::new()),
         ViewId::Config => Box::new(ConfigView::new()),
         ViewId::LoadTest => Box::new(LoadTestView::new()),
+        ViewId::FlashTest => Box::new(FlashTestView::new()),
     }
 }

--- a/crates/basectl/src/app/views/flashtest.rs
+++ b/crates/basectl/src/app/views/flashtest.rs
@@ -1,0 +1,376 @@
+use crossterm::event::{KeyCode, KeyEvent};
+use flashtest::{FlashTestPhase, FlashTestStatus};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    prelude::*,
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState},
+};
+
+use crate::{
+    app::{Action, Resources, View},
+    commands::common::{COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_ROW_SELECTED},
+    tui::Keybinding,
+};
+
+const KEYBINDINGS: &[Keybinding] = &[
+    Keybinding { key: "Esc/q", description: "Quit" },
+    Keybinding { key: "?", description: "Toggle help" },
+    Keybinding { key: "Up/k", description: "Scroll up" },
+    Keybinding { key: "Down/j", description: "Scroll down" },
+    Keybinding { key: "Enter", description: "Show error details" },
+];
+
+#[derive(Debug)]
+struct DashboardState {
+    table_state: TableState,
+    /// Whether to show the error detail panel.
+    show_detail: bool,
+}
+
+impl DashboardState {
+    fn new() -> Self {
+        let mut table_state = TableState::default();
+        table_state.select(Some(0));
+        Self { table_state, show_detail: false }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FlashTestView {
+    dashboard: Option<DashboardState>,
+}
+
+impl FlashTestView {
+    pub const fn new() -> Self {
+        Self { dashboard: None }
+    }
+}
+
+impl View for FlashTestView {
+    fn keybindings(&self) -> &'static [Keybinding] {
+        KEYBINDINGS
+    }
+
+    fn tick(&mut self, resources: &mut Resources) -> Action {
+        if let Some(ref mut ft) = resources.flashtest {
+            ft.poll();
+            if self.dashboard.is_none() {
+                self.dashboard = Some(DashboardState::new());
+            }
+        } else {
+            self.dashboard = None;
+        }
+        Action::None
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, resources: &mut Resources) -> Action {
+        self.dashboard.as_mut().map_or(Action::None, |state| handle_key(key, state, resources))
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, resources: &Resources) {
+        if let Some(state) = self.dashboard.as_mut() {
+            render_dashboard(frame, area, resources, state);
+        } else {
+            render_idle(frame, area);
+        }
+    }
+}
+
+fn render_idle(frame: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .title(" Flash Test ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "No flash test active",
+            Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Run: basectl flashtest --rpc-url <endpoint>",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let para = Paragraph::new(lines).alignment(Alignment::Center);
+    frame.render_widget(para, inner);
+}
+
+fn handle_key(key: KeyEvent, state: &mut DashboardState, resources: &Resources) -> Action {
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            if let Some(selected) = state.table_state.selected()
+                && selected > 0
+            {
+                state.table_state.select(Some(selected - 1));
+            }
+            state.show_detail = false;
+            Action::None
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if let Some(selected) = state.table_state.selected() {
+                let max =
+                    resources.flashtest.as_ref().map_or(0, |ft| ft.results.len().saturating_sub(1));
+                if selected < max {
+                    state.table_state.select(Some(selected + 1));
+                }
+            }
+            state.show_detail = false;
+            Action::None
+        }
+        KeyCode::PageUp => {
+            if let Some(selected) = state.table_state.selected() {
+                let new_pos = selected.saturating_sub(10);
+                state.table_state.select(Some(new_pos));
+            }
+            state.show_detail = false;
+            Action::None
+        }
+        KeyCode::PageDown => {
+            if let Some(selected) = state.table_state.selected() {
+                let max =
+                    resources.flashtest.as_ref().map_or(0, |ft| ft.results.len().saturating_sub(1));
+                let new_pos = (selected + 10).min(max);
+                state.table_state.select(Some(new_pos));
+            }
+            state.show_detail = false;
+            Action::None
+        }
+        KeyCode::Enter => {
+            state.show_detail = !state.show_detail;
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn render_dashboard(
+    frame: &mut Frame,
+    area: Rect,
+    resources: &Resources,
+    state: &mut DashboardState,
+) {
+    let Some(ft) = &resources.flashtest else {
+        render_idle(frame, area);
+        return;
+    };
+
+    let is_complete = ft.phase == FlashTestPhase::Complete;
+
+    // Layout: header + optional banner + body + optional detail
+    let show_detail = state.show_detail
+        && state.table_state.selected().is_some_and(|idx| {
+            ft.results
+                .get(idx)
+                .is_some_and(|r| r.status == FlashTestStatus::Failed && r.error.is_some())
+        });
+
+    let mut constraints = vec![Constraint::Length(1)]; // header
+    if is_complete {
+        constraints.push(Constraint::Length(1)); // banner
+    }
+    if show_detail {
+        constraints.push(Constraint::Min(8)); // table
+        constraints.push(Constraint::Length(6)); // detail
+    } else {
+        constraints.push(Constraint::Min(0)); // table
+    }
+
+    let chunks =
+        Layout::default().direction(Direction::Vertical).constraints(constraints).split(area);
+
+    let mut chunk_idx = 0;
+
+    // Header
+    render_header(frame, chunks[chunk_idx], ft);
+    chunk_idx += 1;
+
+    // Completion banner
+    if is_complete {
+        render_completion_banner(frame, chunks[chunk_idx], ft);
+        chunk_idx += 1;
+    }
+
+    // Table
+    render_table(frame, chunks[chunk_idx], ft, &mut state.table_state);
+    chunk_idx += 1;
+
+    // Detail panel
+    if show_detail
+        && let Some(idx) = state.table_state.selected()
+        && let Some(entry) = ft.results.get(idx)
+    {
+        render_detail(frame, chunks[chunk_idx], entry);
+    }
+}
+
+fn render_header(f: &mut Frame, area: Rect, ft: &flashtest::FlashTestState) {
+    let progress = ft.passed + ft.failed + ft.skipped;
+    let total_str =
+        if ft.total > 0 { format!("{}/{}", progress, ft.total) } else { format!("{progress}") };
+
+    let phase_color = match ft.phase {
+        FlashTestPhase::Running => Color::Green,
+        FlashTestPhase::Complete => Color::Cyan,
+    };
+
+    let spans = vec![
+        Span::styled(
+            " FLASH TEST ",
+            Style::default().fg(Color::Black).bg(COLOR_BASE_BLUE).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(&ft.rpc_url, Style::default().fg(Color::White)),
+        Span::raw("  "),
+        Span::styled(total_str, Style::default().fg(Color::Cyan)),
+        Span::raw("  "),
+        Span::styled(format!("{} pass", ft.passed), Style::default().fg(Color::Green)),
+        Span::raw(" "),
+        Span::styled(
+            format!("{} fail", ft.failed),
+            Style::default().fg(if ft.failed > 0 { Color::Red } else { Color::DarkGray }),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{} skip", ft.skipped),
+            Style::default().fg(if ft.skipped > 0 { Color::Yellow } else { Color::DarkGray }),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("[{}]", ft.phase),
+            Style::default().fg(phase_color).add_modifier(Modifier::BOLD),
+        ),
+    ];
+
+    let para = Paragraph::new(Line::from(spans));
+    f.render_widget(para, area);
+}
+
+fn render_completion_banner(f: &mut Frame, area: Rect, ft: &flashtest::FlashTestState) {
+    let (text, bg_color) = if ft.failed == 0 {
+        (format!("ALL TESTS PASSED - {} passed, {} skipped", ft.passed, ft.skipped), Color::Green)
+    } else {
+        (
+            format!(
+                "{} FAILED - {} passed, {} failed, {} skipped",
+                ft.failed, ft.passed, ft.failed, ft.skipped
+            ),
+            Color::Red,
+        )
+    };
+
+    let para = Paragraph::new(text)
+        .style(Style::default().fg(Color::White).bg(bg_color).add_modifier(Modifier::BOLD))
+        .alignment(Alignment::Center);
+
+    f.render_widget(para, area);
+}
+
+fn render_table(
+    f: &mut Frame,
+    area: Rect,
+    ft: &flashtest::FlashTestState,
+    table_state: &mut TableState,
+) {
+    let block = Block::default()
+        .title(" Results ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_ACTIVE_BORDER));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if ft.results.is_empty() {
+        let para =
+            Paragraph::new("Waiting for tests...").style(Style::default().fg(Color::DarkGray));
+        f.render_widget(para, inner);
+        return;
+    }
+
+    let header_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+    let header = Row::new(vec![
+        Cell::from("Status").style(header_style),
+        Cell::from("Category").style(header_style),
+        Cell::from("Test").style(header_style),
+        Cell::from("Duration").style(header_style),
+    ]);
+
+    let rows: Vec<Row> = ft
+        .results
+        .iter()
+        .enumerate()
+        .map(|(idx, entry)| {
+            let is_selected = table_state.selected() == Some(idx);
+
+            let row_style = if is_selected {
+                Style::default().bg(COLOR_ROW_SELECTED)
+            } else {
+                Style::default()
+            };
+
+            let (status_str, status_style) = match entry.status {
+                FlashTestStatus::Running => {
+                    ("RUN ", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+                }
+                FlashTestStatus::Passed => ("PASS", Style::default().fg(Color::Green)),
+                FlashTestStatus::Failed => {
+                    ("FAIL", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+                }
+                FlashTestStatus::Skipped => ("SKIP", Style::default().fg(Color::Yellow)),
+            };
+
+            let duration_str = entry.duration.map_or_else(
+                || {
+                    if entry.status == FlashTestStatus::Running {
+                        "...".to_string()
+                    } else {
+                        "-".to_string()
+                    }
+                },
+                |d| format!("{}ms", d.as_millis()),
+            );
+
+            Row::new(vec![
+                Cell::from(status_str).style(status_style),
+                Cell::from(entry.category.as_str()).style(Style::default().fg(Color::Cyan)),
+                Cell::from(entry.name.as_str()),
+                Cell::from(duration_str).style(Style::default().fg(Color::DarkGray)),
+            ])
+            .style(row_style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(6),
+        Constraint::Length(14),
+        Constraint::Min(20),
+        Constraint::Length(10),
+    ];
+
+    let table = Table::new(rows, widths).header(header);
+    f.render_stateful_widget(table, inner, table_state);
+}
+
+fn render_detail(f: &mut Frame, area: Rect, entry: &flashtest::FlashTestResultEntry) {
+    let block = Block::default()
+        .title(format!(" Error: {} ", entry.name))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Red));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let error_text = entry.error.as_deref().unwrap_or("Unknown error");
+
+    let para = Paragraph::new(error_text)
+        .style(Style::default().fg(Color::Red))
+        .wrap(ratatui::widgets::Wrap { trim: true });
+
+    f.render_widget(para, inner);
+}

--- a/crates/basectl/src/app/views/mod.rs
+++ b/crates/basectl/src/app/views/mod.rs
@@ -3,6 +3,7 @@ mod config;
 mod da_monitor;
 mod factory;
 mod flashblocks;
+mod flashtest;
 mod home;
 mod loadtest;
 
@@ -11,5 +12,6 @@ pub use config::ConfigView;
 pub use da_monitor::DaMonitorView;
 pub use factory::create_view;
 pub use flashblocks::FlashblocksView;
+pub use flashtest::FlashTestView;
 pub use home::HomeView;
 pub use loadtest::LoadTestView;

--- a/crates/flashtest/Cargo.toml
+++ b/crates/flashtest/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "flashtest"
+description = "End-to-end functional test suite for Base flashblocks RPC"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Base
+base-bundles.workspace = true
+base-flashtypes.workspace = true
+
+# Async runtime
+tokio = { workspace = true }
+tokio-tungstenite.workspace = true
+futures-util.workspace = true
+
+# RPC client
+alloy-provider.workspace = true
+alloy-rpc-client.workspace = true
+alloy-rpc-types-eth.workspace = true
+
+# Ethereum types
+alloy-primitives.workspace = true
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+alloy-sol-types.workspace = true
+alloy-sol-macro = { workspace = true, features = ["json"] }
+
+# Signing
+alloy-signer.workspace = true
+alloy-signer-local.workspace = true
+alloy-network.workspace = true
+
+# OP Stack
+op-alloy-network.workspace = true
+op-alloy-rpc-types.workspace = true
+
+# Serialization
+serde = { workspace = true }
+serde_json.workspace = true
+serde_yaml.workspace = true
+
+# Error handling
+eyre.workspace = true
+
+# Logging
+tracing.workspace = true
+
+# Compression
+brotli.workspace = true
+
+# Misc
+url.workspace = true
+hex.workspace = true

--- a/crates/flashtest/src/client.rs
+++ b/crates/flashtest/src/client.rs
@@ -1,0 +1,435 @@
+//! Test client for connecting to a live node-reth instance.
+
+use std::sync::Arc;
+
+use alloy_consensus::SignableTransaction;
+use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, B256, Bytes, FixedBytes, U256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_client::RpcClient;
+use alloy_rpc_types_eth::{Filter, Log};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use eyre::{Result, WrapErr};
+use op_alloy_network::Optimism;
+use op_alloy_rpc_types::{OpTransactionReceipt, OpTransactionRequest};
+use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::Message;
+use url::Url;
+
+use crate::{
+    harness::{WebSocketSubscription, decode_ws_message},
+    types::{Bundle, MeterBundleResponse, OpBlock},
+};
+
+/// Client for interacting with a live node-reth instance.
+#[derive(Debug)]
+pub struct TestClient {
+    /// HTTP provider for standard RPC calls.
+    provider: RootProvider<Optimism>,
+    /// Raw RPC client for custom methods.
+    rpc_client: RpcClient,
+    /// HTTP RPC URL for the node being tested.
+    pub rpc_url: String,
+    /// Flashblocks WebSocket URL (sequencer/builder endpoint).
+    pub flashblocks_ws_url: String,
+    /// Transaction signer (optional - only if private key provided).
+    signer: Option<PrivateKeySigner>,
+    /// Recipient address for ETH transfers in tests.
+    recipient: Option<Address>,
+    /// Simulator contract address for state root timing tests.
+    simulator: Option<Address>,
+    /// Chain ID for signing transactions.
+    chain_id: u64,
+    /// Tracked nonce for the signer address (to avoid race conditions with remote sequencers).
+    next_nonce: Arc<Mutex<Option<u64>>>,
+}
+
+impl TestClient {
+    /// Create a new test client connected to the given endpoints.
+    ///
+    /// # Arguments
+    /// * `rpc_url` - HTTP RPC endpoint URL
+    /// * `flashblocks_ws_url` - Flashblocks WebSocket URL
+    /// * `private_key` - Optional hex-encoded private key for signing transactions
+    /// * `recipient` - Optional recipient address for ETH transfers in tests
+    /// * `simulator` - Optional Simulator contract address for state root timing tests
+    ///
+    /// # Errors
+    /// Returns an error if recipient equals the signer address.
+    pub async fn new(
+        rpc_url: &str,
+        flashblocks_ws_url: &str,
+        private_key: Option<&str>,
+        recipient: Option<Address>,
+        simulator: Option<Address>,
+    ) -> Result<Self> {
+        let url: Url = rpc_url.parse().wrap_err("Invalid RPC URL")?;
+
+        // Build provider using RpcClient directly (similar to node-reth's test harness)
+        let http_client = RpcClient::builder().http(url.clone());
+        let provider = RootProvider::<Optimism>::new(http_client);
+
+        let rpc_client = RpcClient::new_http(url);
+
+        // Fetch chain ID from the node
+        let chain_id = provider.get_chain_id().await.wrap_err("Failed to get chain ID from RPC")?;
+        tracing::info!(chain_id, "Connected to chain");
+
+        // Parse private key if provided
+        let signer = if let Some(key) = private_key { Some(parse_private_key(key)?) } else { None };
+
+        // Validate recipient != sender
+        if let (Some(s), Some(r)) = (&signer, recipient)
+            && s.address() == r
+        {
+            return Err(eyre::eyre!(
+                "Recipient address cannot be the same as the signer address ({})",
+                r
+            ));
+        }
+
+        Ok(Self {
+            provider,
+            rpc_client,
+            rpc_url: rpc_url.to_string(),
+            flashblocks_ws_url: flashblocks_ws_url.to_string(),
+            signer,
+            recipient,
+            simulator,
+            chain_id,
+            next_nonce: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    /// Check if we have a signer configured.
+    pub const fn has_signer(&self) -> bool {
+        self.signer.is_some()
+    }
+
+    /// Get the signer's address, if configured.
+    pub fn signer_address(&self) -> Option<Address> {
+        self.signer.as_ref().map(|s| s.address())
+    }
+
+    /// Get the recipient address for ETH transfers, if configured.
+    pub const fn recipient(&self) -> Option<Address> {
+        self.recipient
+    }
+
+    /// Get the Simulator contract address, if configured.
+    pub const fn simulator(&self) -> Option<Address> {
+        self.simulator
+    }
+
+    /// Get the chain ID.
+    pub const fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
+    /// Get the next nonce for the signer, tracking it locally to avoid race conditions.
+    ///
+    /// On first call, fetches from pending state. Subsequent calls increment locally.
+    /// This prevents "nonce too low" errors when testing against remote sequencers
+    /// where the pending state may not immediately reflect forwarded transactions.
+    ///
+    /// Call `reset_nonce()` if a transaction fails and you need to re-fetch.
+    pub async fn get_next_nonce(&self) -> Result<u64> {
+        let mut guard = self.next_nonce.lock().await;
+        let nonce = match *guard {
+            Some(n) => n,
+            None => {
+                let from =
+                    self.signer_address().ok_or_else(|| eyre::eyre!("No signer configured"))?;
+                self.get_transaction_count(from, BlockNumberOrTag::Pending).await?
+            }
+        };
+        *guard = Some(nonce + 1);
+        Ok(nonce)
+    }
+
+    /// Peek at the current nonce without incrementing.
+    ///
+    /// Use this for transactions that will only be simulated (e.g., metering) and not
+    /// actually sent to the network. For transactions that will be sent, use
+    /// `get_next_nonce()` instead.
+    pub async fn peek_nonce(&self) -> Result<u64> {
+        let guard = self.next_nonce.lock().await;
+        match *guard {
+            Some(n) => Ok(n),
+            None => {
+                let from =
+                    self.signer_address().ok_or_else(|| eyre::eyre!("No signer configured"))?;
+                self.get_transaction_count(from, BlockNumberOrTag::Pending).await
+            }
+        }
+    }
+
+    /// Reset the tracked nonce (e.g., after a failed transaction).
+    pub async fn reset_nonce(&self) {
+        let mut guard = self.next_nonce.lock().await;
+        *guard = None;
+    }
+
+    /// Get the underlying provider.
+    pub const fn provider(&self) -> &RootProvider<Optimism> {
+        &self.provider
+    }
+
+    /// Get block by number.
+    pub async fn get_block_by_number(&self, block: BlockNumberOrTag) -> Result<Option<OpBlock>> {
+        self.provider.get_block_by_number(block).await.wrap_err("Failed to get block by number")
+    }
+
+    /// Get balance at address.
+    pub async fn get_balance(&self, address: Address, block: BlockNumberOrTag) -> Result<U256> {
+        self.provider
+            .get_balance(address)
+            .block_id(block.into())
+            .await
+            .wrap_err("Failed to get balance")
+    }
+
+    /// Get transaction count (nonce) for address.
+    pub async fn get_transaction_count(
+        &self,
+        address: Address,
+        block: BlockNumberOrTag,
+    ) -> Result<u64> {
+        self.provider
+            .get_transaction_count(address)
+            .block_id(block.into())
+            .await
+            .wrap_err("Failed to get transaction count")
+    }
+
+    /// Execute `eth_call`.
+    pub async fn eth_call(
+        &self,
+        tx: &OpTransactionRequest,
+        block: BlockNumberOrTag,
+    ) -> Result<Bytes> {
+        self.provider.call(tx.clone()).block(block.into()).await.wrap_err("eth_call failed")
+    }
+
+    /// Estimate gas for transaction.
+    pub async fn estimate_gas(
+        &self,
+        tx: &OpTransactionRequest,
+        block: BlockNumberOrTag,
+    ) -> Result<u64> {
+        self.provider
+            .estimate_gas(tx.clone())
+            .block(block.into())
+            .await
+            .wrap_err("Failed to estimate gas")
+    }
+
+    /// Get transaction by hash.
+    pub async fn get_transaction_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<Option<op_alloy_rpc_types::Transaction>> {
+        self.provider
+            .get_transaction_by_hash(hash)
+            .await
+            .wrap_err("Failed to get transaction by hash")
+    }
+
+    /// Get transaction receipt.
+    pub async fn get_transaction_receipt(
+        &self,
+        hash: B256,
+    ) -> Result<Option<OpTransactionReceipt>> {
+        self.provider
+            .get_transaction_receipt(hash)
+            .await
+            .wrap_err("Failed to get transaction receipt")
+    }
+
+    /// Get logs matching filter.
+    pub async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>> {
+        self.provider.get_logs(filter).await.wrap_err("Failed to get logs")
+    }
+
+    /// Sign a transaction request and return the raw transaction bytes and hash.
+    pub fn sign_transaction(&self, tx_request: OpTransactionRequest) -> Result<(Bytes, B256)> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("No signer configured - set PRIVATE_KEY"))?;
+
+        // Build the typed transaction
+        let tx = tx_request
+            .build_typed_tx()
+            .map_err(|e| eyre::eyre!("Failed to build typed tx: {:?}", e))?;
+
+        // Sign it
+        let signature = signer.sign_hash_sync(&tx.signature_hash())?;
+        let signed_tx = tx.into_signed(signature);
+
+        // Encode and return
+        let tx_bytes = Bytes::from(signed_tx.encoded_2718());
+        let tx_hash = *signed_tx.hash();
+
+        Ok((tx_bytes, tx_hash))
+    }
+
+    /// Create and sign a simple ETH transfer transaction.
+    ///
+    /// If `nonce` is `None`, uses the tracked nonce from `get_next_nonce()` to avoid
+    /// race conditions when testing against remote sequencers.
+    pub async fn create_transfer(
+        &self,
+        to: Address,
+        value: U256,
+        nonce: Option<u64>,
+    ) -> Result<(Bytes, B256)> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("No signer configured - set PRIVATE_KEY"))?;
+
+        let from = signer.address();
+
+        // Get nonce - use tracked nonce if not explicitly provided
+        let nonce = match nonce {
+            Some(n) => {
+                // Ensure the local nonce tracker is at least the next value after the provided
+                // nonce so subsequent calls stay monotonic even when explicit nonces are used.
+                let mut guard = self.next_nonce.lock().await;
+                if guard.is_none_or(|current| current < n + 1) {
+                    *guard = Some(n + 1);
+                }
+                n
+            }
+            None => self.get_next_nonce().await?,
+        };
+
+        let mut tx_request = OpTransactionRequest::default()
+            .from(from)
+            .to(to)
+            .value(value)
+            .nonce(nonce)
+            .gas_limit(21_000)
+            .max_fee_per_gas(1_000_000_000) // 1 gwei
+            .max_priority_fee_per_gas(1_000_000);
+        tx_request.set_chain_id(self.chain_id);
+
+        self.sign_transaction(tx_request)
+    }
+
+    /// Send a signed raw transaction.
+    pub async fn send_raw_transaction(&self, tx: Bytes) -> Result<B256> {
+        self.provider
+            .send_raw_transaction(&tx)
+            .await
+            .wrap_err("Failed to send raw transaction")
+            .map(|pending| *pending.tx_hash())
+    }
+
+    /// Send raw transaction and wait for receipt (sync mode).
+    pub async fn send_raw_transaction_sync(
+        &self,
+        tx: Bytes,
+        timeout_ms: Option<u64>,
+    ) -> Result<OpTransactionReceipt> {
+        self.rpc_client
+            .request::<_, OpTransactionReceipt>("eth_sendRawTransactionSync", (tx, timeout_ms))
+            .await
+            .wrap_err("eth_sendRawTransactionSync failed")
+    }
+
+    /// Send ETH and wait for confirmation.
+    pub async fn send_eth_and_wait(
+        &self,
+        to: Address,
+        value: U256,
+    ) -> Result<OpTransactionReceipt> {
+        let (tx_bytes, tx_hash) = self.create_transfer(to, value, None).await?;
+        tracing::debug!(?tx_hash, "Sending transaction");
+
+        // Use sync mode to wait for receipt
+        self.send_raw_transaction_sync(tx_bytes, Some(6_000)).await
+    }
+
+    /// Call `base_meterBundle` RPC method.
+    pub async fn meter_bundle(&self, bundle: Bundle) -> Result<MeterBundleResponse> {
+        self.rpc_client
+            .request::<_, MeterBundleResponse>("base_meterBundle", (bundle,))
+            .await
+            .wrap_err("base_meterBundle failed")
+    }
+
+    /// Call `base_meteredPriorityFeePerGas` RPC method.
+    pub async fn metered_priority_fee(
+        &self,
+        bundle: Bundle,
+    ) -> Result<crate::types::MeteredPriorityFeeResponse> {
+        self.rpc_client
+            .request::<_, crate::types::MeteredPriorityFeeResponse>(
+                "base_meteredPriorityFeePerGas",
+                (bundle,),
+            )
+            .await
+            .wrap_err("base_meteredPriorityFeePerGas failed")
+    }
+
+    /// Connect to WebSocket and subscribe to a topic.
+    pub async fn ws_subscribe(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<WebSocketSubscription> {
+        use futures_util::{SinkExt, StreamExt};
+        use tokio_tungstenite::connect_async;
+
+        let (mut ws_stream, _) = connect_async(&self.flashblocks_ws_url)
+            .await
+            .wrap_err("Failed to connect to WebSocket")?;
+
+        let subscribe_msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_subscribe",
+            "params": [method, params]
+        });
+
+        ws_stream
+            .send(Message::Text(subscribe_msg.to_string().into()))
+            .await
+            .wrap_err("Failed to send subscribe message")?;
+
+        // Wait for subscription confirmation
+        let response = ws_stream
+            .next()
+            .await
+            .ok_or_else(|| eyre::eyre!("WebSocket closed unexpectedly"))?
+            .wrap_err("Failed to receive subscription response")?;
+
+        let json_str = decode_ws_message(&response)?;
+        let sub_response: serde_json::Value =
+            serde_json::from_str(&json_str).wrap_err("Failed to parse subscription response")?;
+
+        let subscription_id = sub_response["result"]
+            .as_str()
+            .ok_or_else(|| eyre::eyre!("No subscription ID in response"))?
+            .to_string();
+
+        Ok(WebSocketSubscription { stream: ws_stream, subscription_id })
+    }
+}
+
+/// Parse a private key from hex string (with or without 0x prefix).
+fn parse_private_key(key: &str) -> Result<PrivateKeySigner> {
+    let key = key.strip_prefix("0x").unwrap_or(key);
+    let key_bytes = hex::decode(key).wrap_err("Invalid hex in private key")?;
+
+    if key_bytes.len() != 32 {
+        return Err(eyre::eyre!("Private key must be 32 bytes, got {}", key_bytes.len()));
+    }
+
+    let key_fixed: FixedBytes<32> = FixedBytes::from_slice(&key_bytes);
+    PrivateKeySigner::from_bytes(&key_fixed).wrap_err("Invalid private key")
+}

--- a/crates/flashtest/src/harness.rs
+++ b/crates/flashtest/src/harness.rs
@@ -1,0 +1,377 @@
+//! Flashblocks streaming and test harness.
+
+use std::{collections::HashSet, io::Read as _, time::Duration};
+
+use alloy_primitives::{B256, keccak256};
+use eyre::{Result, WrapErr};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::{TestClient, types::Flashblock};
+
+/// Decode a WebSocket message, handling both text and brotli-compressed binary.
+///
+/// The flashblocks endpoint sends brotli-compressed binary messages for efficiency.
+pub fn decode_ws_message(msg: &Message) -> Result<String> {
+    match msg {
+        Message::Text(text) => Ok(text.to_string()),
+        Message::Binary(data) => {
+            // Try brotli decompression
+            let mut decompressor = brotli::Decompressor::new(&data[..], 4096);
+            let mut decompressed = Vec::new();
+            decompressor
+                .read_to_end(&mut decompressed)
+                .wrap_err("Failed to decompress brotli data")?;
+
+            String::from_utf8(decompressed).wrap_err("Decompressed data is not valid UTF-8")
+        }
+        Message::Ping(_) | Message::Pong(_) => Err(eyre::eyre!("Unexpected ping/pong message")),
+        Message::Close(_) => Err(eyre::eyre!("WebSocket closed")),
+        Message::Frame(_) => Err(eyre::eyre!("Unexpected raw frame")),
+    }
+}
+
+/// Active WebSocket subscription.
+pub struct WebSocketSubscription {
+    /// The underlying WebSocket stream.
+    pub stream: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    /// The subscription ID.
+    pub subscription_id: String,
+}
+
+impl std::fmt::Debug for WebSocketSubscription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebSocketSubscription")
+            .field("subscription_id", &self.subscription_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WebSocketSubscription {
+    /// Receive the next notification.
+    ///
+    /// Handles both text messages and brotli-compressed binary messages
+    /// (the flashblocks endpoint uses brotli compression).
+    pub async fn next_notification(&mut self) -> Result<serde_json::Value> {
+        use futures_util::StreamExt;
+
+        let msg = self
+            .stream
+            .next()
+            .await
+            .ok_or_else(|| eyre::eyre!("WebSocket closed"))?
+            .wrap_err("Failed to receive message")?;
+
+        let json_str = decode_ws_message(&msg)?;
+
+        let notification: serde_json::Value =
+            serde_json::from_str(&json_str).wrap_err("Failed to parse notification")?;
+
+        Ok(notification)
+    }
+
+    /// Unsubscribe and close the connection.
+    pub async fn unsubscribe(mut self) -> Result<()> {
+        use futures_util::SinkExt;
+
+        let unsubscribe_msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "eth_unsubscribe",
+            "params": [self.subscription_id]
+        });
+
+        self.stream
+            .send(Message::Text(unsubscribe_msg.to_string().into()))
+            .await
+            .wrap_err("Failed to send unsubscribe")?;
+
+        Ok(())
+    }
+}
+
+/// Direct streaming connection to the flashblocks WebSocket endpoint.
+///
+/// Unlike `WebSocketSubscription`, this doesn't use `eth_subscribe` - it just
+/// connects and immediately starts receiving flashblock messages.
+pub struct FlashblocksStream {
+    stream: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+}
+
+impl std::fmt::Debug for FlashblocksStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlashblocksStream").finish_non_exhaustive()
+    }
+}
+
+impl FlashblocksStream {
+    /// Connect to the flashblocks WebSocket endpoint.
+    pub async fn connect(url: &str) -> Result<Self> {
+        use tokio_tungstenite::connect_async;
+
+        let (ws_stream, _) =
+            connect_async(url).await.wrap_err("Failed to connect to flashblocks WebSocket")?;
+
+        Ok(Self { stream: ws_stream })
+    }
+
+    /// Receive the next flashblock message.
+    pub async fn next_flashblock(&mut self) -> Result<Flashblock> {
+        use futures_util::StreamExt;
+
+        loop {
+            let msg = self
+                .stream
+                .next()
+                .await
+                .ok_or_else(|| eyre::eyre!("Flashblocks WebSocket closed"))?
+                .wrap_err("Failed to receive flashblock message")?;
+
+            // Handle ping/pong internally
+            if msg.is_ping() || msg.is_pong() {
+                continue;
+            }
+
+            // Extract bytes from message
+            let bytes: Vec<u8> = match msg {
+                Message::Text(text) => text.as_bytes().to_vec(),
+                Message::Binary(data) => data.to_vec(),
+                Message::Close(_) => return Err(eyre::eyre!("WebSocket closed")),
+                _ => continue,
+            };
+
+            let flashblock = Flashblock::try_decode_message(bytes)
+                .map_err(|e| eyre::eyre!("Failed to decode flashblock: {}", e))?;
+
+            return Ok(flashblock);
+        }
+    }
+
+    /// Close the connection.
+    pub async fn close(self) -> Result<()> {
+        // Just drop the stream - it will close gracefully
+        drop(self.stream);
+        Ok(())
+    }
+}
+
+/// Harness for running tests within a flashblock window.
+///
+/// This ensures tests can:
+/// 1. Wait for flashblock 0/1 of a new block (fresh start)
+/// 2. Query pre-state
+/// 3. Send transactions
+/// 4. See them appear in flashblocks (same block)
+/// 5. Query post-state
+/// 6. Confirm no flashblocks for the next block were received
+pub struct FlashblockHarness {
+    stream: FlashblocksStream,
+    /// The block number we're operating in.
+    block_number: u64,
+    /// Count of flashblocks received for current block.
+    flashblock_count: u64,
+    /// Transaction hashes seen in the current block (from all flashblocks).
+    seen_tx_hashes: HashSet<B256>,
+    /// The most recent flashblock received.
+    current_flashblock: Option<Flashblock>,
+}
+
+impl std::fmt::Debug for FlashblockHarness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlashblockHarness")
+            .field("block_number", &self.block_number)
+            .field("flashblock_count", &self.flashblock_count)
+            .field("seen_tx_hashes", &self.seen_tx_hashes.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl FlashblockHarness {
+    /// Create a new harness and wait for the start of a fresh block.
+    ///
+    /// Connects to the flashblocks WebSocket and waits until we see flashblock
+    /// index 0 or 1 of a new block, ensuring we have a full block window to work with.
+    /// This is critical because tests need to send transactions and see them in
+    /// pending state BEFORE the block is committed.
+    pub async fn new(client: &TestClient) -> Result<Self> {
+        let stream = FlashblocksStream::connect(&client.flashblocks_ws_url).await?;
+
+        tracing::debug!("Connected to flashblocks stream");
+
+        let mut harness = Self {
+            stream,
+            block_number: 0,
+            flashblock_count: 0,
+            seen_tx_hashes: HashSet::new(),
+            current_flashblock: None,
+        };
+
+        // Wait for the start of a fresh block (index 0 or 1)
+        // This ensures we have most of the block window available for our test
+        loop {
+            let flashblock = harness.wait_for_next_flashblock().await?;
+            let fb_index = flashblock.index;
+            let fb_block = flashblock.metadata.block_number;
+
+            if fb_index <= 1 {
+                tracing::info!(
+                    block_number = fb_block,
+                    flashblock_index = fb_index,
+                    "Harness ready at start of block"
+                );
+                break;
+            }
+            tracing::debug!(
+                block_number = fb_block,
+                flashblock_index = fb_index,
+                "Waiting for fresh block start (index 0 or 1)..."
+            );
+        }
+
+        Ok(harness)
+    }
+
+    /// Wait for the next flashblock.
+    /// Updates internal state and returns the new flashblock.
+    pub async fn wait_for_next_flashblock(&mut self) -> Result<&Flashblock> {
+        let flashblock = self.stream.next_flashblock().await?;
+
+        let new_block_number = flashblock.metadata.block_number;
+
+        if new_block_number != self.block_number {
+            // New block started - reset tracking
+            self.block_number = new_block_number;
+            self.flashblock_count = 1;
+            self.seen_tx_hashes.clear();
+            tracing::debug!(block_number = new_block_number, "New block started");
+        } else {
+            self.flashblock_count += 1;
+        }
+
+        // Track all transaction hashes from this flashblock's transactions
+        for tx_bytes in &flashblock.diff.transactions {
+            self.seen_tx_hashes.insert(keccak256(tx_bytes));
+        }
+
+        tracing::trace!(
+            block_number = self.block_number,
+            flashblock_index = flashblock.index,
+            flashblock_count = self.flashblock_count,
+            tx_count = flashblock.diff.transactions.len(),
+            "Received flashblock"
+        );
+
+        self.current_flashblock = Some(flashblock);
+        Ok(self.current_flashblock.as_ref().unwrap())
+    }
+
+    /// Wait for a transaction to appear in a flashblock within the current block.
+    ///
+    /// This waits for the transaction to appear in a flashblock. If a new block
+    /// starts before the transaction is seen, this fails - the test must complete
+    /// within a single block window to properly test pending state visibility.
+    pub async fn wait_for_tx(&mut self, tx_hash: B256, timeout: Duration) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        let starting_block = self.block_number;
+
+        // Check if we already have the tx
+        if self.seen_tx_hashes.contains(&tx_hash) {
+            tracing::debug!(
+                ?tx_hash,
+                block = self.block_number,
+                "Transaction already seen in flashblock"
+            );
+            return Ok(());
+        }
+
+        loop {
+            // Wait for next flashblock with timeout
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(eyre::eyre!(
+                    "Timeout waiting for tx {:?} in flashblock (block {})",
+                    tx_hash,
+                    starting_block
+                ));
+            }
+
+            match tokio::time::timeout(remaining, self.stream.next_flashblock()).await {
+                Ok(Ok(flashblock)) => {
+                    let new_block_number = flashblock.metadata.block_number;
+
+                    if new_block_number != self.block_number {
+                        // Block boundary crossed - fail the test
+                        return Err(eyre::eyre!(
+                            "Block {} ended before tx {:?} appeared in pending state. \
+                             New block {} started. This can happen if the RPC node forwards \
+                             transactions to a remote sequencer with latency.",
+                            starting_block,
+                            tx_hash,
+                            new_block_number
+                        ));
+                    }
+
+                    self.flashblock_count += 1;
+
+                    // Track all transaction hashes from this flashblock
+                    for tx_bytes in &flashblock.diff.transactions {
+                        self.seen_tx_hashes.insert(keccak256(tx_bytes));
+                    }
+
+                    if self.seen_tx_hashes.contains(&tx_hash) {
+                        tracing::debug!(
+                            ?tx_hash,
+                            block = self.block_number,
+                            "Transaction found in flashblock"
+                        );
+                        self.current_flashblock = Some(flashblock);
+                        return Ok(());
+                    }
+
+                    self.current_flashblock = Some(flashblock);
+                }
+                Ok(Err(e)) => return Err(e),
+                Err(_) => {
+                    return Err(eyre::eyre!(
+                        "Timeout waiting for tx {:?} in flashblock (block {})",
+                        tx_hash,
+                        starting_block
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Assert that we're still in the same block (no next block flashblocks received).
+    ///
+    /// This is called after test operations to confirm everything happened
+    /// within a single block's flashblock window.
+    pub fn assert_same_block(&self, expected_block: u64) -> Result<()> {
+        if self.block_number != expected_block {
+            return Err(eyre::eyre!(
+                "Block changed during test: expected {}, now at {}",
+                expected_block,
+                self.block_number
+            ));
+        }
+        Ok(())
+    }
+
+    /// Get the current block number we're operating in.
+    pub const fn block_number(&self) -> u64 {
+        self.block_number
+    }
+
+    /// Get the count of flashblocks received for the current block.
+    pub const fn flashblock_count(&self) -> u64 {
+        self.flashblock_count
+    }
+
+    /// Close the stream.
+    pub async fn close(self) -> Result<()> {
+        self.stream.close().await
+    }
+}

--- a/crates/flashtest/src/lib.rs
+++ b/crates/flashtest/src/lib.rs
@@ -1,0 +1,255 @@
+//! End-to-end functional test suite for Base flashblocks RPC.
+
+mod client;
+pub use client::TestClient;
+
+pub mod harness;
+pub use harness::{FlashblockHarness, FlashblocksStream, WebSocketSubscription};
+
+mod runner;
+pub use runner::{TestEvent, TestResult};
+
+pub mod simulator;
+pub use simulator::{
+    PrecompileConfig, Simulator, SimulatorConfig, SimulatorConfigBuilder, encode_run_call,
+};
+
+pub mod types;
+pub use types::{
+    Bundle, ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock,
+    FlashblockMetadata, MeterBundleResponse, MeteredPriorityFeeResponse, OpBlock,
+    TransactionResult,
+};
+
+pub mod suite;
+use std::time::Duration;
+
+use alloy_primitives::Address;
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+pub use suite::{SkipFn, Test, TestCategory, TestFn, TestSuite, build_test_suite};
+use tokio::sync::mpsc;
+
+/// Configuration for starting a flash test.
+///
+/// Chain-level settings (RPC URL, flashblocks WS URL) come from basectl's
+/// `ChainConfig` (via `-c mainnet|sepolia|devnet`). This struct holds the
+/// test-specific settings that can optionally be loaded from a YAML file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FlashTestConfig {
+    /// Optional private key for signing transactions.
+    pub private_key: Option<String>,
+    /// Optional recipient address for ETH transfers.
+    pub recipient: Option<Address>,
+    /// Optional Simulator contract address.
+    pub simulator: Option<Address>,
+    /// Optional test filter (glob pattern).
+    pub filter: Option<String>,
+}
+
+impl FlashTestConfig {
+    /// Load configuration from a YAML file.
+    pub fn load(path: &str) -> Result<Self> {
+        let contents = std::fs::read_to_string(path)
+            .wrap_err_with(|| format!("failed to read config file: {path}"))?;
+        serde_yaml::from_str(&contents).wrap_err("failed to parse config YAML")
+    }
+}
+
+/// Current phase of the flash test run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashTestPhase {
+    /// Tests are currently running.
+    Running,
+    /// All tests have completed.
+    Complete,
+}
+
+impl std::fmt::Display for FlashTestPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Running => write!(f, "Running"),
+            Self::Complete => write!(f, "Complete"),
+        }
+    }
+}
+
+/// A single test result for display.
+#[derive(Debug, Clone)]
+pub struct FlashTestResultEntry {
+    /// Category name.
+    pub category: String,
+    /// Test name.
+    pub name: String,
+    /// Test status.
+    pub status: FlashTestStatus,
+    /// Duration (if completed).
+    pub duration: Option<Duration>,
+    /// Error message (if failed).
+    pub error: Option<String>,
+    /// Skip reason (if skipped).
+    pub skip_reason: Option<String>,
+}
+
+/// Status of a test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashTestStatus {
+    /// Test is currently running.
+    Running,
+    /// Test passed.
+    Passed,
+    /// Test failed.
+    Failed,
+    /// Test was skipped.
+    Skipped,
+}
+
+/// Aggregated state of the flash test run, polled by the TUI.
+#[derive(Debug)]
+pub struct FlashTestState {
+    /// Individual test results.
+    pub results: Vec<FlashTestResultEntry>,
+    /// Current phase.
+    pub phase: FlashTestPhase,
+    /// Number of passed tests.
+    pub passed: usize,
+    /// Number of failed tests.
+    pub failed: usize,
+    /// Number of skipped tests.
+    pub skipped: usize,
+    /// Total number of tests expected (may be 0 if unknown).
+    pub total: usize,
+    /// RPC URL being tested.
+    pub rpc_url: String,
+    /// Event channel receiver.
+    event_rx: Option<mpsc::Receiver<TestEvent>>,
+}
+
+impl FlashTestState {
+    /// Create a new state with an event channel.
+    pub const fn new(event_rx: mpsc::Receiver<TestEvent>, rpc_url: String) -> Self {
+        Self {
+            results: Vec::new(),
+            phase: FlashTestPhase::Running,
+            passed: 0,
+            failed: 0,
+            skipped: 0,
+            total: 0,
+            rpc_url,
+            event_rx: Some(event_rx),
+        }
+    }
+
+    /// Drain all pending events from the channel, updating state.
+    pub fn poll(&mut self) {
+        let Some(ref mut rx) = self.event_rx else {
+            return;
+        };
+
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                TestEvent::TestStarted { category, name } => {
+                    self.results.push(FlashTestResultEntry {
+                        category,
+                        name,
+                        status: FlashTestStatus::Running,
+                        duration: None,
+                        error: None,
+                        skip_reason: None,
+                    });
+                }
+                TestEvent::TestPassed { category, name, duration } => {
+                    if let Some(entry) = self
+                        .results
+                        .iter_mut()
+                        .rev()
+                        .find(|e| e.category == category && e.name == name)
+                    {
+                        entry.status = FlashTestStatus::Passed;
+                        entry.duration = Some(duration);
+                    }
+                    self.passed += 1;
+                }
+                TestEvent::TestFailed { category, name, duration, error } => {
+                    if let Some(entry) = self
+                        .results
+                        .iter_mut()
+                        .rev()
+                        .find(|e| e.category == category && e.name == name)
+                    {
+                        entry.status = FlashTestStatus::Failed;
+                        entry.duration = Some(duration);
+                        entry.error = Some(error);
+                    } else {
+                        // Connection failure before TestStarted
+                        self.results.push(FlashTestResultEntry {
+                            category,
+                            name,
+                            status: FlashTestStatus::Failed,
+                            duration: Some(duration),
+                            error: Some(error),
+                            skip_reason: None,
+                        });
+                    }
+                    self.failed += 1;
+                }
+                TestEvent::TestSkipped { category, name, reason } => {
+                    if let Some(entry) = self
+                        .results
+                        .iter_mut()
+                        .rev()
+                        .find(|e| e.category == category && e.name == name)
+                    {
+                        entry.status = FlashTestStatus::Skipped;
+                        entry.skip_reason = Some(reason);
+                    }
+                    self.skipped += 1;
+                }
+                TestEvent::SuiteComplete { passed, failed, skipped } => {
+                    self.passed = passed;
+                    self.failed = failed;
+                    self.skipped = skipped;
+                    self.total = passed + failed + skipped;
+                    self.phase = FlashTestPhase::Complete;
+                }
+            }
+        }
+    }
+}
+
+/// Handle to a running flash test.
+#[derive(Debug)]
+pub struct FlashTestHandle {
+    /// Event channel receiver.
+    pub event_rx: mpsc::Receiver<TestEvent>,
+}
+
+/// Start a flash test and return a handle for receiving events.
+///
+/// `rpc_url` and `flashblocks_ws_url` come from basectl's `ChainConfig`.
+/// `config` holds test-specific options (keys, addresses, filter).
+pub async fn start_flash_test(
+    rpc_url: &str,
+    flashblocks_ws_url: &str,
+    config: FlashTestConfig,
+) -> Result<FlashTestHandle> {
+    let client = TestClient::new(
+        rpc_url,
+        flashblocks_ws_url,
+        config.private_key.as_deref(),
+        config.recipient,
+        config.simulator,
+    )
+    .await?;
+
+    let suite = build_test_suite();
+    let filter = config.filter.clone();
+
+    let (event_tx, event_rx) = mpsc::channel(256);
+
+    tokio::spawn(async move {
+        runner::run_tests(&client, &suite, filter.as_deref(), &event_tx).await;
+    });
+
+    Ok(FlashTestHandle { event_rx })
+}

--- a/crates/flashtest/src/runner.rs
+++ b/crates/flashtest/src/runner.rs
@@ -1,0 +1,253 @@
+//! Test runner adapted for channel-based output.
+
+use std::time::{Duration, Instant};
+
+use alloy_eips::BlockNumberOrTag;
+use serde::Serialize;
+use tokio::sync::mpsc;
+
+use crate::{
+    TestClient,
+    suite::{Test, TestSuite},
+};
+
+/// Result of running a single test.
+#[derive(Debug, Clone, Serialize)]
+pub struct TestResult {
+    /// Name of the test.
+    pub name: String,
+    /// Category the test belongs to.
+    pub category: String,
+    /// Whether the test passed.
+    pub passed: bool,
+    /// Duration in milliseconds.
+    pub duration_ms: u64,
+    /// Error message if the test failed.
+    pub error: Option<String>,
+    /// Whether the test was skipped.
+    pub skipped: bool,
+    /// Reason for skipping if applicable.
+    pub skip_reason: Option<String>,
+}
+
+/// Events emitted during test execution.
+#[derive(Debug, Clone)]
+pub enum TestEvent {
+    /// A test is about to start.
+    TestStarted {
+        /// Category name.
+        category: String,
+        /// Test name.
+        name: String,
+    },
+    /// A test passed.
+    TestPassed {
+        /// Category name.
+        category: String,
+        /// Test name.
+        name: String,
+        /// How long the test took.
+        duration: Duration,
+    },
+    /// A test failed.
+    TestFailed {
+        /// Category name.
+        category: String,
+        /// Test name.
+        name: String,
+        /// How long the test took.
+        duration: Duration,
+        /// Error description.
+        error: String,
+    },
+    /// A test was skipped.
+    TestSkipped {
+        /// Category name.
+        category: String,
+        /// Test name.
+        name: String,
+        /// Why it was skipped.
+        reason: String,
+    },
+    /// The entire suite finished.
+    SuiteComplete {
+        /// Number of passing tests.
+        passed: usize,
+        /// Number of failing tests.
+        failed: usize,
+        /// Number of skipped tests.
+        skipped: usize,
+    },
+}
+
+/// Run tests, emitting events via the channel.
+pub(crate) async fn run_tests(
+    client: &TestClient,
+    suite: &TestSuite,
+    filter: Option<&str>,
+    event_tx: &mpsc::Sender<TestEvent>,
+) {
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+    let mut skipped = 0usize;
+
+    // Check connection first
+    match client.get_block_by_number(BlockNumberOrTag::Latest).await {
+        Ok(Some(_)) | Ok(None) => {}
+        Err(e) => {
+            let _ = event_tx
+                .send(TestEvent::TestFailed {
+                    category: "setup".to_string(),
+                    name: "connection".to_string(),
+                    duration: Duration::ZERO,
+                    error: e.to_string(),
+                })
+                .await;
+            failed += 1;
+            let _ = event_tx.send(TestEvent::SuiteComplete { passed, failed, skipped }).await;
+            return;
+        }
+    }
+
+    for category in &suite.categories {
+        let category_tests: Vec<&Test> =
+            category.tests.iter().filter(|t| matches_filter(&t.name, filter)).collect();
+
+        if category_tests.is_empty() {
+            continue;
+        }
+
+        for test in category_tests {
+            let _ = event_tx
+                .send(TestEvent::TestStarted {
+                    category: category.name.clone(),
+                    name: test.name.clone(),
+                })
+                .await;
+
+            let result = run_single_test(client, &category.name, test).await;
+
+            if result.skipped {
+                skipped += 1;
+                let _ = event_tx
+                    .send(TestEvent::TestSkipped {
+                        category: category.name.clone(),
+                        name: test.name.clone(),
+                        reason: result.skip_reason.unwrap_or_default(),
+                    })
+                    .await;
+            } else if result.passed {
+                passed += 1;
+                let _ = event_tx
+                    .send(TestEvent::TestPassed {
+                        category: category.name.clone(),
+                        name: test.name.clone(),
+                        duration: Duration::from_millis(result.duration_ms),
+                    })
+                    .await;
+            } else {
+                failed += 1;
+                let _ = event_tx
+                    .send(TestEvent::TestFailed {
+                        category: category.name.clone(),
+                        name: test.name.clone(),
+                        duration: Duration::from_millis(result.duration_ms),
+                        error: result.error.unwrap_or_default(),
+                    })
+                    .await;
+            }
+        }
+    }
+
+    let _ = event_tx.send(TestEvent::SuiteComplete { passed, failed, skipped }).await;
+}
+
+/// Run a single test.
+async fn run_single_test(client: &TestClient, category: &str, test: &Test) -> TestResult {
+    let start = Instant::now();
+
+    // Check skip condition
+    if let Some(ref skip_fn) = test.skip_if
+        && let Some(reason) = skip_fn(client).await
+    {
+        return TestResult {
+            name: test.name.clone(),
+            category: category.to_string(),
+            passed: true,
+            duration_ms: start.elapsed().as_millis() as u64,
+            error: None,
+            skipped: true,
+            skip_reason: Some(reason),
+        };
+    }
+
+    // Run the test
+    let result = tokio::time::timeout(Duration::from_secs(30), (test.run)(client)).await;
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    match result {
+        Ok(Ok(())) => TestResult {
+            name: test.name.clone(),
+            category: category.to_string(),
+            passed: true,
+            duration_ms,
+            error: None,
+            skipped: false,
+            skip_reason: None,
+        },
+        Ok(Err(e)) => TestResult {
+            name: test.name.clone(),
+            category: category.to_string(),
+            passed: false,
+            duration_ms,
+            error: Some(format!("{e:#}")),
+            skipped: false,
+            skip_reason: None,
+        },
+        Err(_) => TestResult {
+            name: test.name.clone(),
+            category: category.to_string(),
+            passed: false,
+            duration_ms,
+            error: Some("Test timed out after 30s".to_string()),
+            skipped: false,
+            skip_reason: None,
+        },
+    }
+}
+
+/// Check if test name matches filter.
+fn matches_filter(name: &str, filter: Option<&str>) -> bool {
+    match filter {
+        None => true,
+        Some(f) => {
+            if f.contains('*') {
+                let parts: Vec<&str> = f.split('*').collect();
+                let mut remaining = name;
+                for (i, part) in parts.iter().enumerate() {
+                    if part.is_empty() {
+                        continue;
+                    }
+                    if i == 0 {
+                        if !remaining.starts_with(part) {
+                            return false;
+                        }
+                        remaining = &remaining[part.len()..];
+                    } else if i == parts.len() - 1 {
+                        if !remaining.ends_with(part) {
+                            return false;
+                        }
+                    } else if let Some(pos) = remaining.find(part) {
+                        remaining = &remaining[pos + part.len()..];
+                    } else {
+                        return false;
+                    }
+                }
+                true
+            } else {
+                name.contains(f)
+            }
+        }
+    }
+}

--- a/crates/flashtest/src/simulator.rs
+++ b/crates/flashtest/src/simulator.rs
@@ -1,0 +1,147 @@
+//! Simulator contract bindings for resource usage testing.
+//!
+//! The Simulator contract from base-benchmark enables configurable resource
+//! consumption for testing bundle metering. It can create storage slots,
+//! accounts, and call precompiles to generate different types of load.
+//!
+//! This is useful for testing:
+//! - `state_root_time_us`: Create accounts/storage to increase state root time
+//! - `total_execution_time_us`: Call precompiles to increase execution time
+//! - `total_gas_used`: Storage operations consume gas
+
+use alloy_primitives::{Address, Bytes, U160, U256};
+use alloy_sol_types::SolCall;
+
+// Define the Simulator contract ABI using alloy's sol! macro
+alloy_sol_macro::sol! {
+    /// Configuration for precompile calls.
+    struct PrecompileConfig {
+        address precompile_address;
+        uint256 num_calls;
+    }
+
+    /// Configuration for the `Simulator.run()` call.
+    ///
+    /// Each field controls a different type of resource consumption:
+    /// - `load_accounts`: Read existing accounts (minimal impact)
+    /// - `update_accounts`: Update existing account balances
+    /// - `create_accounts`: Create new accounts (increases state root time)
+    /// - `load_storage`: Read existing storage slots
+    /// - `update_storage`: Update existing storage slots
+    /// - `delete_storage`: Delete storage slots
+    /// - `create_storage`: Create new storage slots (gas pressure)
+    /// - `precompiles`: Call precompiles (execution time)
+    struct SimulatorConfig {
+        uint160 load_accounts;
+        uint160 update_accounts;
+        uint160 create_accounts;
+        uint256 load_storage;
+        uint256 update_storage;
+        uint256 delete_storage;
+        uint256 create_storage;
+        PrecompileConfig[] precompiles;
+    }
+
+    /// The Simulator contract interface.
+    interface Simulator {
+        /// Execute the configured resource operations.
+        function run(SimulatorConfig calldata config) external;
+        /// Initialize a chunk of storage slots for later use.
+        function initialize_storage_chunk() external;
+        /// Initialize a chunk of addresses for later use.
+        function initialize_address_chunk() external;
+    }
+}
+
+/// Encode the `Simulator.run()` call with the given configuration.
+pub fn encode_run_call(config: &SimulatorConfig) -> Bytes {
+    let call = Simulator::runCall { config: config.clone() };
+    Bytes::from(call.abi_encode())
+}
+
+/// Builder for `SimulatorConfig` with sensible defaults.
+#[derive(Debug, Clone, Default)]
+pub struct SimulatorConfigBuilder {
+    create_accounts: u64,
+    create_storage: u64,
+    precompile_calls: u64,
+    precompile_address: Option<Address>,
+}
+
+impl SimulatorConfigBuilder {
+    /// Create a new builder with all zeros.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the number of accounts to create.
+    ///
+    /// Creating accounts increases state root computation time.
+    pub const fn create_accounts(mut self, count: u64) -> Self {
+        self.create_accounts = count;
+        self
+    }
+
+    /// Set the number of storage slots to create.
+    ///
+    /// Creating storage increases gas usage.
+    pub const fn create_storage(mut self, count: u64) -> Self {
+        self.create_storage = count;
+        self
+    }
+
+    /// Set precompile calls for execution time testing.
+    pub const fn precompile_calls(mut self, count: u64, address: Address) -> Self {
+        self.precompile_calls = count;
+        self.precompile_address = Some(address);
+        self
+    }
+
+    /// Build the `SimulatorConfig`.
+    pub fn build(self) -> SimulatorConfig {
+        let precompiles = if self.precompile_calls > 0 {
+            self.precompile_address.map_or_else(Vec::new, |addr| {
+                vec![PrecompileConfig {
+                    precompile_address: addr,
+                    num_calls: U256::from(self.precompile_calls),
+                }]
+            })
+        } else {
+            vec![]
+        };
+
+        SimulatorConfig {
+            load_accounts: U160::ZERO,
+            update_accounts: U160::ZERO,
+            create_accounts: U160::from(self.create_accounts),
+            load_storage: U256::ZERO,
+            update_storage: U256::ZERO,
+            delete_storage: U256::ZERO,
+            create_storage: U256::from(self.create_storage),
+            precompiles,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_run_call() {
+        let config = SimulatorConfigBuilder::new().create_accounts(5).create_storage(10).build();
+
+        let calldata = encode_run_call(&config);
+        assert!(!calldata.is_empty());
+        // The function selector for run(SimulatorConfig) should be at the start
+        assert!(calldata.len() > 4);
+    }
+
+    #[test]
+    fn test_builder_defaults() {
+        let config = SimulatorConfigBuilder::new().build();
+        assert_eq!(config.create_accounts, U160::ZERO);
+        assert_eq!(config.create_storage, U256::ZERO);
+        assert!(config.precompiles.is_empty());
+    }
+}

--- a/crates/flashtest/src/suite/blocks.rs
+++ b/crates/flashtest/src/suite/blocks.rs
@@ -1,0 +1,184 @@
+//! Tests for block retrieval and state visibility.
+
+use std::time::Duration;
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::U256;
+use eyre::{Result, ensure};
+
+use crate::{
+    TestClient,
+    harness::FlashblockHarness,
+    suite::{Test, TestCategory, skip_if_no_signer_or_recipient},
+};
+
+/// Build the blocks test category.
+pub(crate) fn category() -> TestCategory {
+    TestCategory {
+        name: "blocks".to_string(),
+        description: Some("Block retrieval and pending state tests".to_string()),
+        tests: vec![
+            Test {
+                name: "get_latest_block".to_string(),
+                description: Some("Verify we can retrieve the latest block".to_string()),
+                run: Box::new(|client| Box::pin(test_get_latest_block(client))),
+                skip_if: None,
+            },
+            Test {
+                name: "get_pending_block".to_string(),
+                description: Some("Verify we can retrieve the pending block".to_string()),
+                run: Box::new(|client| Box::pin(test_get_pending_block(client))),
+                skip_if: None,
+            },
+            Test {
+                name: "pending_block_number_gt_latest".to_string(),
+                description: Some("Pending block number should be >= latest".to_string()),
+                run: Box::new(|client| Box::pin(test_pending_block_number(client))),
+                skip_if: None,
+            },
+            Test {
+                name: "flashblock_balance_change".to_string(),
+                description: Some(
+                    "Send tx and verify balance change visible in pending state within same block"
+                        .to_string(),
+                ),
+                run: Box::new(|client| Box::pin(test_flashblock_balance_change(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move { skip_if_no_signer_or_recipient(client) })
+                })),
+            },
+            Test {
+                name: "flashblock_nonce_change".to_string(),
+                description: Some(
+                    "Send tx and verify nonce change visible in pending state within same block"
+                        .to_string(),
+                ),
+                run: Box::new(|client| Box::pin(test_flashblock_nonce_change(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move { skip_if_no_signer_or_recipient(client) })
+                })),
+            },
+        ],
+    }
+}
+
+async fn test_get_latest_block(client: &TestClient) -> Result<()> {
+    let block = client.get_block_by_number(BlockNumberOrTag::Latest).await?;
+    ensure!(block.is_some(), "Latest block should exist");
+
+    let block = block.unwrap();
+    tracing::debug!(number = block.header.number, "Got latest block");
+
+    Ok(())
+}
+
+async fn test_get_pending_block(client: &TestClient) -> Result<()> {
+    let block = client.get_block_by_number(BlockNumberOrTag::Pending).await?;
+    ensure!(block.is_some(), "Pending block should exist");
+
+    let block = block.unwrap();
+    tracing::debug!(number = block.header.number, "Got pending block");
+
+    Ok(())
+}
+
+async fn test_pending_block_number(client: &TestClient) -> Result<()> {
+    let latest = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No latest block"))?;
+
+    let pending = client
+        .get_block_by_number(BlockNumberOrTag::Pending)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No pending block"))?;
+
+    ensure!(
+        pending.header.number >= latest.header.number,
+        "Pending block number ({}) should be >= latest ({})",
+        pending.header.number,
+        latest.header.number
+    );
+
+    Ok(())
+}
+
+async fn test_flashblock_balance_change(client: &TestClient) -> Result<()> {
+    let from = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+
+    let mut harness = FlashblockHarness::new(client).await?;
+    let block_number = harness.block_number();
+
+    let balance_before = client.get_balance(from, BlockNumberOrTag::Pending).await?;
+    tracing::debug!(?balance_before, block = block_number, "Balance before tx");
+
+    let value = U256::from(1u64);
+    let recipient = client.recipient().ok_or_else(|| eyre::eyre!("No recipient configured"))?;
+    let (tx_bytes, tx_hash) = client.create_transfer(recipient, value, None).await?;
+
+    tracing::info!(?tx_hash, "Sending transaction");
+    client.send_raw_transaction(tx_bytes).await?;
+
+    harness.wait_for_tx(tx_hash, Duration::from_secs(10)).await?;
+
+    let balance_after = client.get_balance(from, BlockNumberOrTag::Pending).await?;
+    tracing::debug!(?balance_after, "Balance after flashblock tx");
+
+    ensure!(
+        balance_after < balance_before,
+        "Pending balance should decrease after flashblock tx: before={}, after={}",
+        balance_before,
+        balance_after
+    );
+
+    harness.assert_same_block(block_number)?;
+
+    tracing::info!(
+        block = block_number,
+        flashblocks = harness.flashblock_count(),
+        "Balance change verified in pending state within flashblock window"
+    );
+
+    harness.close().await?;
+    Ok(())
+}
+
+async fn test_flashblock_nonce_change(client: &TestClient) -> Result<()> {
+    let from = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+
+    let mut harness = FlashblockHarness::new(client).await?;
+    let block_number = harness.block_number();
+
+    let nonce_before = client.get_transaction_count(from, BlockNumberOrTag::Pending).await?;
+    tracing::debug!(nonce_before, block = block_number, "Nonce before tx");
+
+    let value = U256::from(1u64);
+    let recipient = client.recipient().ok_or_else(|| eyre::eyre!("No recipient configured"))?;
+    let (tx_bytes, tx_hash) = client.create_transfer(recipient, value, Some(nonce_before)).await?;
+
+    tracing::info!(?tx_hash, "Sending transaction");
+    client.send_raw_transaction(tx_bytes).await?;
+
+    harness.wait_for_tx(tx_hash, Duration::from_secs(10)).await?;
+
+    let nonce_after = client.get_transaction_count(from, BlockNumberOrTag::Pending).await?;
+    tracing::debug!(nonce_after, "Nonce after flashblock tx");
+
+    ensure!(
+        nonce_after == nonce_before + 1,
+        "Pending nonce should increment after flashblock tx: before={}, after={}",
+        nonce_before,
+        nonce_after
+    );
+
+    harness.assert_same_block(block_number)?;
+
+    tracing::info!(
+        block = block_number,
+        flashblocks = harness.flashblock_count(),
+        "Nonce change verified in pending state within flashblock window"
+    );
+
+    harness.close().await?;
+    Ok(())
+}

--- a/crates/flashtest/src/suite/call.rs
+++ b/crates/flashtest/src/suite/call.rs
@@ -1,0 +1,175 @@
+//! Tests for `eth_call` and `eth_estimateGas`.
+
+use std::time::Duration;
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{Address, U256};
+use eyre::{Result, ensure};
+use op_alloy_rpc_types::OpTransactionRequest;
+
+use crate::{
+    TestClient,
+    harness::FlashblockHarness,
+    suite::{Test, TestCategory, skip_if_no_addresses, skip_if_no_signer_or_recipient},
+};
+
+/// Build the call test category.
+pub(crate) fn category() -> TestCategory {
+    TestCategory {
+        name: "call".to_string(),
+        description: Some("eth_call and eth_estimateGas tests".to_string()),
+        tests: vec![
+            Test {
+                name: "eth_call_latest".to_string(),
+                description: Some("eth_call against latest block".to_string()),
+                run: Box::new(|client| Box::pin(test_eth_call_latest(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move { skip_if_no_addresses(client) })
+                })),
+            },
+            Test {
+                name: "eth_call_pending".to_string(),
+                description: Some("eth_call against pending block".to_string()),
+                run: Box::new(|client| Box::pin(test_eth_call_pending(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move { skip_if_no_addresses(client) })
+                })),
+            },
+            Test {
+                name: "eth_estimate_gas_latest".to_string(),
+                description: Some("eth_estimateGas against latest block".to_string()),
+                run: Box::new(|client| Box::pin(test_estimate_gas_latest(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move { skip_if_no_addresses(client) })
+                })),
+            },
+            Test {
+                name: "eth_estimate_gas_pending".to_string(),
+                description: Some("eth_estimateGas against pending block".to_string()),
+                run: Box::new(|client| Box::pin(test_estimate_gas_pending(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move { skip_if_no_addresses(client) })
+                })),
+            },
+            Test {
+                name: "flashblock_eth_call_sees_state".to_string(),
+                description: Some(
+                    "eth_call against pending sees state changes from flashblock tx".to_string(),
+                ),
+                run: Box::new(|client| Box::pin(test_flashblock_eth_call_sees_state(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move { skip_if_no_signer_or_recipient(client) })
+                })),
+            },
+        ],
+    }
+}
+
+/// Get a pair of addresses for from/to in tests.
+/// Uses signer as from (if available) and recipient as to (if available).
+fn get_test_addresses(client: &TestClient) -> (Address, Address) {
+    let from = client
+        .signer_address()
+        .or_else(|| client.recipient())
+        .expect("at least one address should be configured");
+    let to = client
+        .recipient()
+        .or_else(|| client.signer_address())
+        .expect("at least one address should be configured");
+    (from, to)
+}
+
+async fn test_eth_call_latest(client: &TestClient) -> Result<()> {
+    let (from, to) = get_test_addresses(client);
+
+    let tx = OpTransactionRequest::default().from(from).to(to).value(U256::ZERO);
+
+    let result = client.eth_call(&tx, BlockNumberOrTag::Latest).await?;
+    tracing::debug!(?result, "eth_call result at latest");
+
+    Ok(())
+}
+
+async fn test_eth_call_pending(client: &TestClient) -> Result<()> {
+    let (from, to) = get_test_addresses(client);
+
+    let tx = OpTransactionRequest::default().from(from).to(to).value(U256::ZERO);
+
+    let result = client.eth_call(&tx, BlockNumberOrTag::Pending).await?;
+    tracing::debug!(?result, "eth_call result at pending");
+
+    Ok(())
+}
+
+async fn test_estimate_gas_latest(client: &TestClient) -> Result<()> {
+    let (from, to) = get_test_addresses(client);
+
+    let tx = OpTransactionRequest::default().from(from).to(to).value(U256::from(1000));
+
+    let gas = client.estimate_gas(&tx, BlockNumberOrTag::Latest).await?;
+    tracing::debug!(gas, "Estimated gas at latest");
+
+    ensure!(gas >= 21000, "Gas estimate should be at least 21000 for transfer");
+    Ok(())
+}
+
+async fn test_estimate_gas_pending(client: &TestClient) -> Result<()> {
+    let (from, to) = get_test_addresses(client);
+
+    let tx = OpTransactionRequest::default().from(from).to(to).value(U256::from(1000));
+
+    let gas = client.estimate_gas(&tx, BlockNumberOrTag::Pending).await?;
+    tracing::debug!(gas, "Estimated gas at pending");
+
+    ensure!(gas >= 21000, "Gas estimate should be at least 21000 for transfer");
+    Ok(())
+}
+
+async fn test_flashblock_eth_call_sees_state(client: &TestClient) -> Result<()> {
+    client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+
+    let recipient = client.recipient().ok_or_else(|| eyre::eyre!("No recipient configured"))?;
+
+    let mut harness = FlashblockHarness::new(client).await?;
+    let block_number = harness.block_number();
+
+    let balance_before = client.get_balance(recipient, BlockNumberOrTag::Pending).await?;
+    tracing::debug!(?balance_before, "Recipient balance before");
+
+    let transfer_amount = U256::from(1u64);
+    let (tx_bytes, tx_hash) = client.create_transfer(recipient, transfer_amount, None).await?;
+
+    tracing::info!(?tx_hash, block = block_number, "Sending ETH to recipient");
+    client.send_raw_transaction(tx_bytes).await?;
+
+    harness.wait_for_tx(tx_hash, Duration::from_secs(10)).await?;
+
+    let balance_after = client.get_balance(recipient, BlockNumberOrTag::Pending).await?;
+    tracing::debug!(?balance_after, "Recipient balance after flashblock tx");
+
+    ensure!(
+        balance_after > balance_before,
+        "Recipient balance should increase: before={}, after={}",
+        balance_before,
+        balance_after
+    );
+
+    ensure!(
+        balance_after >= balance_before + transfer_amount,
+        "Recipient should have at least transfer amount more: before={}, after={}, transfer={}",
+        balance_before,
+        balance_after,
+        transfer_amount
+    );
+
+    harness.assert_same_block(block_number)?;
+
+    tracing::info!(
+        block = block_number,
+        flashblocks = harness.flashblock_count(),
+        "eth_call state visibility verified in pending state within flashblock window"
+    );
+
+    harness.close().await?;
+    Ok(())
+}

--- a/crates/flashtest/src/suite/contracts.rs
+++ b/crates/flashtest/src/suite/contracts.rs
@@ -1,0 +1,159 @@
+//! Tests for contract interactions via flashblocks.
+
+use std::time::Duration;
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_sol_types::SolCall;
+use eyre::{Result, ensure};
+use op_alloy_rpc_types::OpTransactionRequest;
+
+use crate::{
+    TestClient,
+    harness::FlashblockHarness,
+    suite::{Test, TestCategory, skip_if_no_signer},
+};
+
+// Define the Counter contract interface using sol! macro for ABI encoding.
+// The bytecode is compiled separately with forge (solc 0.8.30).
+//
+// Source (src/Counter.sol):
+// ```solidity
+// // SPDX-License-Identifier: UNLICENSED
+// pragma solidity ^0.8.20;
+// contract Counter {
+//     uint256 public count;
+//     function increment() external { count++; }
+//     function getCount() external view returns (uint256) { return count; }
+// }
+// ```
+alloy_sol_macro::sol! {
+    /// Increment the counter.
+    function increment() external;
+    /// Get the current count.
+    function getCount() external view returns (uint256);
+}
+
+// Counter contract bytecode compiled with forge (solc 0.8.30)
+// count is stored in slot 0, anyone can increment
+const COUNTER_BYTECODE: &str = "6080604052348015600e575f5ffd5b506101898061001c5f395ff3fe608060405234801561000f575f5ffd5b506004361061003f575f3560e01c806306661abd14610043578063a87d942c14610061578063d09de08a1461007f575b5f5ffd5b61004b610089565b60405161005891906100c6565b60405180910390f35b61006961008e565b60405161007691906100c6565b60405180910390f35b610087610096565b005b5f5481565b5f5f54905090565b5f5f8154809291906100a79061010c565b9190505550565b5f819050919050565b6100c0816100ae565b82525050565b5f6020820190506100d95f8301846100b7565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f610116826100ae565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203610148576101476100df565b5b60018201905091905056fea2646970667358221220f20d10175682bbbd1b6bb8f4176629c4124ad6a6532bcaf2cfaa2ed6771b941a64736f6c634300081e0033";
+
+/// Build the contracts test category.
+pub(crate) fn category() -> TestCategory {
+    TestCategory {
+        name: "contracts".to_string(),
+        description: Some("Contract deployment and interaction tests".to_string()),
+        tests: vec![Test {
+            name: "flashblock_counter_increment".to_string(),
+            description: Some(
+                "Deploy Counter, increment, and verify state change in flashblock".to_string(),
+            ),
+            run: Box::new(|client| Box::pin(test_flashblock_counter_increment(client))),
+            skip_if: Some(Box::new(|client| Box::pin(async move { skip_if_no_signer(client) }))),
+        }],
+    }
+}
+
+async fn test_flashblock_counter_increment(client: &TestClient) -> Result<()> {
+    client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+
+    let contract_address = deploy_counter(client).await?;
+    tracing::info!(?contract_address, "Counter contract deployed");
+
+    let mut harness = FlashblockHarness::new(client).await?;
+    let block_number = harness.block_number();
+
+    let count_before = call_get_count(client, contract_address).await?;
+    tracing::debug!(count = %count_before, block = block_number, "Count before increment");
+
+    ensure!(count_before == U256::ZERO, "Initial count should be 0, got {}", count_before);
+
+    let (tx_bytes, tx_hash) = create_increment_tx(client, contract_address).await?;
+
+    tracing::info!(?tx_hash, block = block_number, "Sending increment transaction");
+    client.send_raw_transaction(tx_bytes).await?;
+
+    harness.wait_for_tx(tx_hash, Duration::from_secs(10)).await?;
+
+    let count_after = call_get_count(client, contract_address).await?;
+    tracing::debug!(count = %count_after, "Count after flashblock tx");
+
+    ensure!(count_after == U256::from(1), "Count should be 1 after increment, got {}", count_after);
+
+    harness.assert_same_block(block_number)?;
+
+    tracing::info!(
+        block = block_number,
+        flashblocks = harness.flashblock_count(),
+        "Counter increment verified in pending state within flashblock window"
+    );
+
+    harness.close().await?;
+    Ok(())
+}
+
+async fn deploy_counter(client: &TestClient) -> Result<Address> {
+    let owner = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+
+    let bytecode = hex::decode(COUNTER_BYTECODE)
+        .map_err(|e| eyre::eyre!("Failed to decode bytecode: {}", e))?;
+
+    let nonce = client.get_next_nonce().await?;
+
+    let mut tx_request = OpTransactionRequest::default()
+        .from(owner)
+        .with_deploy_code(Bytes::from(bytecode))
+        .nonce(nonce)
+        .gas_limit(500_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000);
+    tx_request.set_chain_id(client.chain_id());
+
+    let (tx_bytes, tx_hash) = client.sign_transaction(tx_request)?;
+    tracing::debug!(?tx_hash, "Deploying Counter contract");
+
+    let receipt = client.send_raw_transaction_sync(tx_bytes, Some(6_000)).await?;
+
+    ensure!(receipt.inner.inner.status(), "Contract deployment failed");
+
+    let contract_address = receipt
+        .inner
+        .contract_address
+        .ok_or_else(|| eyre::eyre!("No contract address in receipt"))?;
+
+    Ok(contract_address)
+}
+
+async fn call_get_count(client: &TestClient, contract: Address) -> Result<U256> {
+    let call_data = getCountCall {}.abi_encode();
+
+    let tx = OpTransactionRequest::default().to(contract).input(Bytes::from(call_data).into());
+
+    let result = client.eth_call(&tx, BlockNumberOrTag::Pending).await?;
+
+    let count = getCountCall::abi_decode_returns(&result)
+        .map_err(|e| eyre::eyre!("Failed to decode getCount result: {}", e))?;
+
+    Ok(count)
+}
+
+async fn create_increment_tx(client: &TestClient, contract: Address) -> Result<(Bytes, B256)> {
+    let owner = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+
+    let call_data = incrementCall {}.abi_encode();
+
+    let nonce = client.get_next_nonce().await?;
+
+    let mut tx_request = OpTransactionRequest::default()
+        .from(owner)
+        .to(contract)
+        .input(Bytes::from(call_data).into())
+        .nonce(nonce)
+        .gas_limit(100_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000);
+    tx_request.set_chain_id(client.chain_id());
+
+    client.sign_transaction(tx_request)
+}

--- a/crates/flashtest/src/suite/logs.rs
+++ b/crates/flashtest/src/suite/logs.rs
@@ -1,0 +1,100 @@
+//! Tests for `eth_getLogs`.
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_rpc_types_eth::Filter;
+use eyre::Result;
+
+use crate::{
+    TestClient,
+    suite::{Test, TestCategory},
+};
+
+/// Build the logs test category.
+pub(crate) fn category() -> TestCategory {
+    TestCategory {
+        name: "logs".to_string(),
+        description: Some("eth_getLogs tests including pending logs".to_string()),
+        tests: vec![
+            Test {
+                name: "get_logs_latest".to_string(),
+                description: Some("Get logs from latest block".to_string()),
+                run: Box::new(|client| Box::pin(test_get_logs_latest(client))),
+                skip_if: None,
+            },
+            Test {
+                name: "get_logs_pending".to_string(),
+                description: Some("Get logs including pending block".to_string()),
+                run: Box::new(|client| Box::pin(test_get_logs_pending(client))),
+                skip_if: None,
+            },
+            Test {
+                name: "get_logs_range".to_string(),
+                description: Some("Get logs from a block range".to_string()),
+                run: Box::new(|client| Box::pin(test_get_logs_range(client))),
+                skip_if: None,
+            },
+            Test {
+                name: "get_logs_mixed_range".to_string(),
+                description: Some("Get logs from fromBlock: 0, toBlock: pending".to_string()),
+                run: Box::new(|client| Box::pin(test_get_logs_mixed_range(client))),
+                skip_if: None,
+            },
+        ],
+    }
+}
+
+async fn test_get_logs_latest(client: &TestClient) -> Result<()> {
+    let filter = Filter::new().select(BlockNumberOrTag::Latest);
+
+    let logs = client.get_logs(&filter).await?;
+    tracing::debug!(count = logs.len(), "Got logs at latest block");
+
+    Ok(())
+}
+
+async fn test_get_logs_pending(client: &TestClient) -> Result<()> {
+    let filter =
+        Filter::new().from_block(BlockNumberOrTag::Pending).to_block(BlockNumberOrTag::Pending);
+
+    let logs = client.get_logs(&filter).await?;
+    tracing::debug!(count = logs.len(), "Got pending logs");
+
+    Ok(())
+}
+
+async fn test_get_logs_range(client: &TestClient) -> Result<()> {
+    let latest_block = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No latest block"))?;
+
+    let from_block = latest_block.header.number.saturating_sub(10);
+
+    let filter = Filter::new().from_block(from_block).to_block(BlockNumberOrTag::Latest);
+
+    let logs = client.get_logs(&filter).await?;
+    tracing::debug!(
+        count = logs.len(),
+        from = from_block,
+        to = latest_block.header.number,
+        "Got logs in range"
+    );
+
+    Ok(())
+}
+
+async fn test_get_logs_mixed_range(client: &TestClient) -> Result<()> {
+    let latest_block = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No latest block"))?;
+
+    let from_block = latest_block.header.number.saturating_sub(10);
+
+    let filter = Filter::new().from_block(from_block).to_block(BlockNumberOrTag::Pending);
+
+    let logs = client.get_logs(&filter).await?;
+    tracing::debug!(count = logs.len(), from = from_block, "Got logs from historical to pending");
+
+    Ok(())
+}

--- a/crates/flashtest/src/suite/metering.rs
+++ b/crates/flashtest/src/suite/metering.rs
@@ -1,0 +1,514 @@
+//! Tests for metering RPC endpoints.
+//!
+//! These tests require the node to support the `base_meterBundle` RPC method.
+//! Not all nodes have this.
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, B256, U256};
+use eyre::{Result, ensure, eyre};
+use op_alloy_rpc_types::OpTransactionRequest;
+
+use crate::{
+    TestClient,
+    simulator::{SimulatorConfigBuilder, encode_run_call},
+    suite::{Test, TestCategory, skip_if_no_signer_or_recipient, skip_if_no_signer_or_simulator},
+    types::Bundle,
+};
+
+/// Check if the node supports metering RPC methods.
+async fn check_metering_support(client: &TestClient) -> Option<String> {
+    let bundle = Bundle { block_number: 1, ..Default::default() };
+    match client.meter_bundle(bundle).await {
+        Ok(_) => None,
+        Err(e) => {
+            let err_str = format!("{e:?}");
+            if err_str.contains("-32601") || err_str.contains("Method not found") {
+                Some("Node does not support base_meterBundle RPC method".to_string())
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Build the metering test category.
+pub(crate) fn category() -> TestCategory {
+    TestCategory {
+        name: "metering".to_string(),
+        description: Some(
+            "Bundle metering and priority fee estimation tests (requires base_meterBundle support)"
+                .to_string(),
+        ),
+        tests: vec![
+            Test {
+                name: "meter_bundle_empty".to_string(),
+                description: Some("Meter an empty bundle".to_string()),
+                run: Box::new(|client| Box::pin(test_meter_bundle_empty(client))),
+                skip_if: Some(Box::new(|client| Box::pin(check_metering_support(client)))),
+            },
+            Test {
+                name: "meter_bundle_state_block".to_string(),
+                description: Some("Verify metering returns valid state block".to_string()),
+                run: Box::new(|client| Box::pin(test_meter_bundle_state_block(client))),
+                skip_if: Some(Box::new(|client| Box::pin(check_metering_support(client)))),
+            },
+            Test {
+                name: "meter_bundle_with_transaction".to_string(),
+                description: Some("Meter a bundle with a real transaction".to_string()),
+                run: Box::new(|client| Box::pin(test_meter_bundle_with_transaction(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move {
+                        if let Some(reason) = check_metering_support(client).await {
+                            return Some(reason);
+                        }
+                        skip_if_no_signer_or_recipient(client)
+                    })
+                })),
+            },
+            Test {
+                name: "meter_bundle_flashblock_index".to_string(),
+                description: Some(
+                    "Verify metering returns flashblock index when available".to_string(),
+                ),
+                run: Box::new(|client| Box::pin(test_meter_bundle_flashblock_index(client))),
+                skip_if: Some(Box::new(|client| Box::pin(check_metering_support(client)))),
+            },
+            Test {
+                name: "meter_bundle_state_root_timing".to_string(),
+                description: Some(
+                    "Verify metering returns state root timing (ETH transfer)".to_string(),
+                ),
+                run: Box::new(|client| Box::pin(test_meter_bundle_state_root_timing(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move {
+                        if let Some(reason) = check_metering_support(client).await {
+                            return Some(reason);
+                        }
+                        skip_if_no_signer_or_recipient(client)
+                    })
+                })),
+            },
+            Test {
+                name: "meter_bundle_state_root_timing_simulator".to_string(),
+                description: Some(
+                    "Verify metering returns state root timing (Simulator contract)".to_string(),
+                ),
+                run: Box::new(|client| {
+                    Box::pin(test_meter_bundle_state_root_timing_simulator(client))
+                }),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move {
+                        if let Some(reason) = check_metering_support(client).await {
+                            return Some(reason);
+                        }
+                        skip_if_no_signer_or_simulator(client)
+                    })
+                })),
+            },
+            Test {
+                name: "meter_bundle_high_state_root_time".to_string(),
+                description: Some(
+                    "Meter bundle with high state root time (~400 accounts)".to_string(),
+                ),
+                run: Box::new(|client| Box::pin(test_meter_bundle_high_state_root_time(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move {
+                        if let Some(reason) = check_metering_support(client).await {
+                            return Some(reason);
+                        }
+                        skip_if_no_signer_or_simulator(client)
+                    })
+                })),
+            },
+            Test {
+                name: "meter_bundle_high_execution_time".to_string(),
+                description: Some(
+                    "Meter bundle with high execution time (~20k bn256Add calls)".to_string(),
+                ),
+                run: Box::new(|client| Box::pin(test_meter_bundle_high_execution_time(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move {
+                        if let Some(reason) = check_metering_support(client).await {
+                            return Some(reason);
+                        }
+                        skip_if_no_signer_or_simulator(client)
+                    })
+                })),
+            },
+            Test {
+                name: "metered_priority_fee".to_string(),
+                description: Some("Test base_meteredPriorityFeePerGas endpoint".to_string()),
+                run: Box::new(|client| Box::pin(test_metered_priority_fee(client))),
+                skip_if: Some(Box::new(|client| Box::pin(check_metering_support(client)))),
+            },
+        ],
+    }
+}
+
+async fn test_meter_bundle_empty(client: &TestClient) -> Result<()> {
+    let bundle = Bundle { block_number: 1, ..Default::default() };
+
+    let response = client.meter_bundle(bundle).await?;
+
+    ensure!(response.results.is_empty(), "Empty bundle should have no results");
+    ensure!(response.total_gas_used == 0, "Empty bundle should use 0 gas");
+
+    tracing::debug!(state_block = response.state_block_number, "Metered empty bundle");
+
+    Ok(())
+}
+
+async fn test_meter_bundle_state_block(client: &TestClient) -> Result<()> {
+    let bundle = Bundle { block_number: 1, ..Default::default() };
+
+    let response = client.meter_bundle(bundle).await?;
+
+    tracing::debug!(state_block = response.state_block_number, "State block from metering");
+
+    let pending_block = client
+        .get_block_by_number(BlockNumberOrTag::Pending)
+        .await?
+        .ok_or_else(|| eyre!("Pending block unavailable to validate state block"))?;
+
+    let latest_block = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre!("Latest block unavailable to validate state block"))?;
+
+    ensure!(
+        response.state_block_number <= pending_block.header.number,
+        "State block should not be ahead of pending: metering returned {}, pending is {}",
+        response.state_block_number,
+        pending_block.header.number
+    );
+
+    ensure!(
+        response.state_block_number >= latest_block.header.number,
+        "State block should not be older than latest: metering returned {}, latest is {}",
+        response.state_block_number,
+        latest_block.header.number
+    );
+
+    let block =
+        client.get_block_by_number(BlockNumberOrTag::Number(response.state_block_number)).await?;
+    if block.is_none() && response.state_block_number < pending_block.header.number {
+        return Err(eyre!(
+            "State block {} not retrievable even though it should be canonical (latest={}, pending={})",
+            response.state_block_number,
+            latest_block.header.number,
+            pending_block.header.number
+        ));
+    }
+
+    Ok(())
+}
+
+async fn test_meter_bundle_with_transaction(client: &TestClient) -> Result<()> {
+    let from = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+    let to = client.recipient().ok_or_else(|| eyre::eyre!("No recipient configured"))?;
+
+    let latest_block = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No latest block"))?;
+    let block_number = latest_block.header.number + 1;
+
+    let nonce = client.peek_nonce().await?;
+
+    let mut tx_request = OpTransactionRequest::default()
+        .from(from)
+        .to(to)
+        .value(U256::from(1_000_000_000_000_000u64))
+        .nonce(nonce)
+        .gas_limit(21_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000);
+    tx_request.set_chain_id(client.chain_id());
+
+    let (tx_bytes, tx_hash) = client.sign_transaction(tx_request)?;
+
+    let bundle = Bundle { txs: vec![tx_bytes], block_number, ..Default::default() };
+
+    let response = client.meter_bundle(bundle).await?;
+
+    ensure!(response.results.len() == 1, "Should have 1 result, got {}", response.results.len());
+    ensure!(response.total_gas_used > 0, "Should use some gas");
+
+    let tx_result = &response.results[0];
+    ensure!(tx_result.tx_hash == tx_hash, "Transaction hash should match");
+    ensure!(tx_result.from_address == from, "From address should match");
+    ensure!(tx_result.gas_used == 21000, "ETH transfer should use 21000 gas");
+
+    tracing::info!(
+        tx_hash = ?tx_hash,
+        gas_used = response.total_gas_used,
+        execution_time_us = response.total_execution_time_us,
+        state_root_time_us = response.state_root_time_us,
+        "Metered bundle with transaction"
+    );
+
+    Ok(())
+}
+
+async fn test_meter_bundle_flashblock_index(client: &TestClient) -> Result<()> {
+    let bundle = Bundle { block_number: 1, ..Default::default() };
+
+    let response = client.meter_bundle(bundle).await?;
+
+    if let Some(index) = response.state_flashblock_index {
+        tracing::info!(
+            flashblock_index = index,
+            state_block = response.state_block_number,
+            "Metering used flashblock state"
+        );
+    } else {
+        tracing::info!(
+            state_block = response.state_block_number,
+            "Metering used canonical block state (no flashblocks available)"
+        );
+    }
+
+    Ok(())
+}
+
+async fn test_meter_bundle_state_root_timing(client: &TestClient) -> Result<()> {
+    let from = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+    let to = client.recipient().ok_or_else(|| eyre::eyre!("No recipient configured"))?;
+
+    let latest_block = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No latest block"))?;
+    let block_number = latest_block.header.number + 1;
+
+    let nonce = client.peek_nonce().await?;
+
+    let mut tx_request = OpTransactionRequest::default()
+        .from(from)
+        .to(to)
+        .value(U256::from(1_000_000_000_000_000u64))
+        .nonce(nonce)
+        .gas_limit(21_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000);
+    tx_request.set_chain_id(client.chain_id());
+
+    let (tx_bytes, _) = client.sign_transaction(tx_request)?;
+
+    let bundle = Bundle { txs: vec![tx_bytes], block_number, ..Default::default() };
+
+    let response = client.meter_bundle(bundle).await?;
+
+    tracing::info!(
+        state_root_time_us = response.state_root_time_us,
+        total_execution_time_us = response.total_execution_time_us,
+        "State root timing from ETH transfer"
+    );
+
+    ensure!(
+        response.total_gas_used == 21000,
+        "ETH transfer should use exactly 21000 gas, got {}",
+        response.total_gas_used
+    );
+
+    Ok(())
+}
+
+async fn test_meter_bundle_state_root_timing_simulator(client: &TestClient) -> Result<()> {
+    let from = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+    let simulator_addr =
+        client.simulator().ok_or_else(|| eyre::eyre!("No simulator configured"))?;
+
+    let latest_block = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No latest block"))?;
+    let block_number = latest_block.header.number + 1;
+
+    let nonce = client.peek_nonce().await?;
+
+    let config = SimulatorConfigBuilder::new().create_accounts(10).create_storage(50).build();
+    let calldata = encode_run_call(&config);
+
+    let mut tx_request = OpTransactionRequest::default()
+        .from(from)
+        .to(simulator_addr)
+        .input(calldata.into())
+        .nonce(nonce)
+        .gas_limit(2_000_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000);
+    tx_request.set_chain_id(client.chain_id());
+
+    let (tx_bytes, _) = client.sign_transaction(tx_request)?;
+
+    let bundle = Bundle { txs: vec![tx_bytes], block_number, ..Default::default() };
+
+    let response = client.meter_bundle(bundle).await?;
+
+    tracing::info!(
+        state_root_time_us = response.state_root_time_us,
+        total_execution_time_us = response.total_execution_time_us,
+        total_gas_used = response.total_gas_used,
+        "State root timing from Simulator bundle"
+    );
+
+    ensure!(
+        response.total_gas_used > 21000,
+        "Simulator bundle should use more gas than simple transfer, got {}",
+        response.total_gas_used
+    );
+
+    ensure!(
+        response.total_execution_time_us > 0,
+        "Execution time should be positive for simulator workload"
+    );
+
+    Ok(())
+}
+
+async fn test_meter_bundle_high_state_root_time(client: &TestClient) -> Result<()> {
+    let from = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+    let simulator_addr =
+        client.simulator().ok_or_else(|| eyre::eyre!("No simulator configured"))?;
+
+    let latest_block = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No latest block"))?;
+    let block_number = latest_block.header.number + 1;
+
+    let nonce = client.peek_nonce().await?;
+
+    let config = SimulatorConfigBuilder::new().create_accounts(400).build();
+    let calldata = encode_run_call(&config);
+
+    let mut tx_request = OpTransactionRequest::default()
+        .from(from)
+        .to(simulator_addr)
+        .input(calldata.into())
+        .nonce(nonce)
+        .gas_limit(16_500_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000);
+    tx_request.set_chain_id(client.chain_id());
+
+    let (tx_bytes, _) = client.sign_transaction(tx_request)?;
+    let bundle = Bundle { txs: vec![tx_bytes], block_number, ..Default::default() };
+
+    let response = client.meter_bundle(bundle).await?;
+
+    tracing::info!(
+        state_root_time_us = response.state_root_time_us,
+        total_execution_time_us = response.total_execution_time_us,
+        total_gas_used = response.total_gas_used,
+        accounts_created = 400,
+        "High state root time test"
+    );
+
+    ensure!(
+        response.total_gas_used < 16_500_000,
+        "Transaction should not hit gas limit (got {}), reduce account count",
+        response.total_gas_used
+    );
+
+    ensure!(
+        response.total_gas_used >= 8_000_000,
+        "Expected significant gas usage for 400 account creations, got {}",
+        response.total_gas_used
+    );
+
+    ensure!(response.total_execution_time_us > 0, "Execution time should be positive");
+
+    Ok(())
+}
+
+async fn test_meter_bundle_high_execution_time(client: &TestClient) -> Result<()> {
+    let from = client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+    let simulator_addr =
+        client.simulator().ok_or_else(|| eyre::eyre!("No simulator configured"))?;
+
+    let latest_block = client
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("No latest block"))?;
+    let block_number = latest_block.header.number + 1;
+
+    let nonce = client.peek_nonce().await?;
+
+    let bn256_add = Address::from_word(B256::from(U256::from(6)));
+    let config = SimulatorConfigBuilder::new().precompile_calls(15_000, bn256_add).build();
+    let calldata = encode_run_call(&config);
+
+    let mut tx_request = OpTransactionRequest::default()
+        .from(from)
+        .to(simulator_addr)
+        .input(calldata.into())
+        .nonce(nonce)
+        .gas_limit(16_000_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000);
+    tx_request.set_chain_id(client.chain_id());
+
+    let (tx_bytes, _) = client.sign_transaction(tx_request)?;
+    let bundle = Bundle { txs: vec![tx_bytes], block_number, ..Default::default() };
+
+    let response = client.meter_bundle(bundle).await?;
+
+    tracing::info!(
+        state_root_time_us = response.state_root_time_us,
+        total_execution_time_us = response.total_execution_time_us,
+        total_gas_used = response.total_gas_used,
+        precompile_calls = 15_000,
+        "High execution time test"
+    );
+
+    ensure!(
+        response.total_gas_used < 16_000_000,
+        "Transaction should not hit gas limit (got {}), reduce precompile calls",
+        response.total_gas_used
+    );
+
+    ensure!(
+        response.total_gas_used >= 6_000_000,
+        "Expected significant gas usage for 15k precompile calls, got {}",
+        response.total_gas_used
+    );
+
+    ensure!(response.total_execution_time_us > 0, "Execution time should be positive");
+
+    ensure!(
+        response.total_execution_time_us >= response.state_root_time_us,
+        "For precompile-heavy workloads, execution time ({} us) should be >= state root time ({} us)",
+        response.total_execution_time_us,
+        response.state_root_time_us
+    );
+
+    Ok(())
+}
+
+async fn test_metered_priority_fee(client: &TestClient) -> Result<()> {
+    let bundle = Bundle { block_number: 1, ..Default::default() };
+
+    match client.metered_priority_fee(bundle).await {
+        Ok(response) => {
+            tracing::debug!(
+                blocks_sampled = response.blocks_sampled,
+                priority_fee = ?response.priority_fee,
+                "Got metered priority fee"
+            );
+            Ok(())
+        }
+        Err(e) => {
+            let err_str = format!("{e:?}");
+            if err_str.contains("cache") || err_str.contains("empty") || err_str.contains("no data")
+            {
+                tracing::warn!("Metered priority fee not available (no cache data): {}", e);
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}

--- a/crates/flashtest/src/suite/mod.rs
+++ b/crates/flashtest/src/suite/mod.rs
@@ -1,0 +1,146 @@
+//! Test definitions for flashblocks e2e testing.
+
+mod blocks;
+mod call;
+mod contracts;
+mod logs;
+mod metering;
+mod receipts;
+mod subscriptions;
+
+use std::{future::Future, pin::Pin};
+
+use eyre::Result;
+
+use crate::TestClient;
+
+/// A test function that takes a client and returns a result.
+pub type TestFn =
+    Box<dyn Fn(&TestClient) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> + Send + Sync>;
+
+/// A skip condition function that returns Some(reason) if the test should be skipped.
+pub type SkipFn = Box<
+    dyn Fn(&TestClient) -> Pin<Box<dyn Future<Output = Option<String>> + Send + '_>> + Send + Sync,
+>;
+
+/// A single test case.
+pub struct Test {
+    /// Test name (used for filtering).
+    pub name: String,
+    /// Optional description.
+    pub description: Option<String>,
+    /// The test function to run.
+    pub run: TestFn,
+    /// Optional skip condition.
+    pub skip_if: Option<SkipFn>,
+}
+
+impl std::fmt::Debug for Test {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Test")
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A category of related tests.
+#[derive(Debug)]
+pub struct TestCategory {
+    /// Category name.
+    pub name: String,
+    /// Optional description.
+    pub description: Option<String>,
+    /// Tests in this category.
+    pub tests: Vec<Test>,
+}
+
+/// The complete test suite.
+#[derive(Debug)]
+pub struct TestSuite {
+    /// Categories in this test suite.
+    pub categories: Vec<TestCategory>,
+}
+
+/// Helper macro for creating test functions.
+#[macro_export]
+macro_rules! test_fn {
+    ($f:expr) => {
+        Box::new(|client: &$crate::TestClient| Box::pin($f(client)))
+    };
+}
+
+/// Helper macro for creating skip functions.
+#[macro_export]
+macro_rules! skip_fn {
+    ($f:expr) => {
+        Some(Box::new(
+            |client: &$crate::TestClient| -> ::std::pin::Pin<
+                Box<dyn ::std::future::Future<Output = Option<String>> + Send + '_>,
+            > { Box::pin($f(client)) },
+        ) as $crate::suite::SkipFn)
+    };
+}
+
+// ============================================================================
+// Shared skip condition helpers
+// ============================================================================
+
+/// Check if we have a signer configured.
+///
+/// Returns Some(reason) if no signer is available, indicating the test should be skipped.
+pub fn skip_if_no_signer(client: &TestClient) -> Option<String> {
+    if !client.has_signer() { Some("No PRIVATE_KEY configured".to_string()) } else { None }
+}
+
+/// Check if we have both a signer and recipient configured.
+///
+/// Returns Some(reason) if either is missing, indicating the test should be skipped.
+pub fn skip_if_no_signer_or_recipient(client: &TestClient) -> Option<String> {
+    if !client.has_signer() {
+        Some("No PRIVATE_KEY configured".to_string())
+    } else if client.recipient().is_none() {
+        Some("No --recipient configured".to_string())
+    } else {
+        None
+    }
+}
+
+/// Check if we have at least one address configured (signer or recipient).
+///
+/// Returns Some(reason) if neither is available, indicating the test should be skipped.
+pub fn skip_if_no_addresses(client: &TestClient) -> Option<String> {
+    if client.signer_address().is_none() && client.recipient().is_none() {
+        Some("No PRIVATE_KEY or --recipient configured".to_string())
+    } else {
+        None
+    }
+}
+
+/// Check if we have signer and simulator configured.
+///
+/// Returns Some(reason) if either is missing, indicating the test should be skipped.
+pub fn skip_if_no_signer_or_simulator(client: &TestClient) -> Option<String> {
+    if !client.has_signer() {
+        Some("No PRIVATE_KEY configured".to_string())
+    } else if client.simulator().is_none() {
+        Some("No --simulator configured".to_string())
+    } else {
+        None
+    }
+}
+
+/// Build the complete test suite.
+pub fn build_test_suite() -> TestSuite {
+    TestSuite {
+        categories: vec![
+            blocks::category(),
+            call::category(),
+            receipts::category(),
+            logs::category(),
+            subscriptions::category(),
+            metering::category(),
+            contracts::category(),
+        ],
+    }
+}

--- a/crates/flashtest/src/suite/receipts.rs
+++ b/crates/flashtest/src/suite/receipts.rs
@@ -1,0 +1,101 @@
+//! Tests for transaction receipts.
+
+use std::time::Duration;
+
+use alloy_primitives::{U256, b256};
+use eyre::{Result, ensure};
+
+use crate::{
+    TestClient,
+    harness::FlashblockHarness,
+    suite::{Test, TestCategory, skip_if_no_signer_or_recipient},
+};
+
+/// Build the receipts test category.
+pub(crate) fn category() -> TestCategory {
+    TestCategory {
+        name: "receipts".to_string(),
+        description: Some("Transaction receipt retrieval tests".to_string()),
+        tests: vec![
+            Test {
+                name: "get_receipt_nonexistent".to_string(),
+                description: Some("Get receipt for non-existent tx returns None".to_string()),
+                run: Box::new(|client| Box::pin(test_receipt_nonexistent(client))),
+                skip_if: None,
+            },
+            Test {
+                name: "flashblock_receipt".to_string(),
+                description: Some(
+                    "Send tx and verify receipt available in pending state within same block"
+                        .to_string(),
+                ),
+                run: Box::new(|client| Box::pin(test_flashblock_receipt(client))),
+                skip_if: Some(Box::new(|client| {
+                    Box::pin(async move { skip_if_no_signer_or_recipient(client) })
+                })),
+            },
+        ],
+    }
+}
+
+async fn test_receipt_nonexistent(client: &TestClient) -> Result<()> {
+    let fake_hash = b256!("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+
+    let receipt = client.get_transaction_receipt(fake_hash).await?;
+    ensure!(receipt.is_none(), "Receipt for non-existent tx should be None");
+
+    Ok(())
+}
+
+async fn test_flashblock_receipt(client: &TestClient) -> Result<()> {
+    client.signer_address().ok_or_else(|| eyre::eyre!("No signer"))?;
+
+    let recipient = client.recipient().ok_or_else(|| eyre::eyre!("No recipient configured"))?;
+
+    let mut harness = FlashblockHarness::new(client).await?;
+    let block_number = harness.block_number();
+
+    let value = U256::from(1u64);
+    let (tx_bytes, tx_hash) = client.create_transfer(recipient, value, None).await?;
+
+    tracing::info!(?tx_hash, block = block_number, "Sending transaction");
+    client.send_raw_transaction(tx_bytes).await?;
+
+    harness.wait_for_tx(tx_hash, Duration::from_secs(10)).await?;
+
+    let receipt = client.get_transaction_receipt(tx_hash).await?;
+
+    ensure!(
+        receipt.is_some(),
+        "Receipt should be available in pending state after tx appears in flashblock"
+    );
+
+    let receipt = receipt.unwrap();
+
+    ensure!(
+        receipt.inner.transaction_hash == tx_hash,
+        "Receipt tx hash mismatch: expected {}, got {}",
+        tx_hash,
+        receipt.inner.transaction_hash
+    );
+
+    ensure!(receipt.inner.inner.status(), "Transaction should have succeeded");
+
+    tracing::debug!(
+        tx_hash = ?receipt.inner.transaction_hash,
+        block_number = ?receipt.inner.block_number,
+        gas_used = ?receipt.inner.gas_used,
+        "Got flashblock receipt"
+    );
+
+    harness.assert_same_block(block_number)?;
+
+    tracing::info!(
+        block = block_number,
+        flashblocks = harness.flashblock_count(),
+        "Receipt verified in pending state within flashblock window"
+    );
+
+    harness.close().await?;
+    Ok(())
+}

--- a/crates/flashtest/src/suite/subscriptions.rs
+++ b/crates/flashtest/src/suite/subscriptions.rs
@@ -1,0 +1,71 @@
+//! Sanity checks for the flashblocks WebSocket endpoint.
+//!
+//! These tests verify the flashblocks WebSocket is reachable and streaming correctly.
+//! They do NOT test the RPC node - they test the external flashblocks endpoint
+//! (--flashblocks-ws-url) which is a prerequisite for the flashblock-aware tests.
+
+use std::time::Duration;
+
+use eyre::{Result, ensure};
+
+use crate::{
+    TestClient,
+    harness::FlashblocksStream,
+    suite::{Test, TestCategory},
+};
+
+/// Build the sanity checks category.
+pub(crate) fn category() -> TestCategory {
+    TestCategory {
+        name: "sanity".to_string(),
+        description: Some(
+            "Sanity checks for flashblocks WebSocket (tests the endpoint, not the RPC node)"
+                .to_string(),
+        ),
+        tests: vec![
+            Test {
+                name: "flashblocks_ws_connect".to_string(),
+                description: Some("Verify flashblocks WebSocket is reachable".to_string()),
+                run: Box::new(|client| Box::pin(test_flashblocks_stream_connect(client))),
+                skip_if: None,
+            },
+            Test {
+                name: "flashblocks_ws_receive".to_string(),
+                description: Some("Verify flashblocks are being streamed".to_string()),
+                run: Box::new(|client| Box::pin(test_flashblocks_stream_receive(client))),
+                skip_if: None,
+            },
+        ],
+    }
+}
+
+async fn test_flashblocks_stream_connect(client: &TestClient) -> Result<()> {
+    let stream = FlashblocksStream::connect(&client.flashblocks_ws_url).await?;
+
+    tracing::debug!("Connected to flashblocks stream");
+
+    stream.close().await?;
+
+    Ok(())
+}
+
+async fn test_flashblocks_stream_receive(client: &TestClient) -> Result<()> {
+    let mut stream = FlashblocksStream::connect(&client.flashblocks_ws_url).await?;
+
+    let flashblock = tokio::time::timeout(Duration::from_secs(5), stream.next_flashblock())
+        .await
+        .map_err(|_| eyre::eyre!("Timeout waiting for flashblock"))??;
+
+    tracing::debug!(
+        block_number = flashblock.metadata.block_number,
+        index = flashblock.index,
+        tx_count = flashblock.diff.transactions.len(),
+        "Received flashblock"
+    );
+
+    ensure!(flashblock.metadata.block_number > 0, "Block number should be positive");
+
+    stream.close().await?;
+
+    Ok(())
+}

--- a/crates/flashtest/src/types.rs
+++ b/crates/flashtest/src/types.rs
@@ -1,0 +1,24 @@
+//! RPC types for flashblocks testing.
+
+use alloy_primitives::U256;
+// Re-export metering types from base-bundles
+pub use base_bundles::{Bundle, MeterBundleResponse, TransactionResult};
+// Re-export flashblock types from base-flashtypes
+pub use base_flashtypes::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, FlashblockDecodeError,
+    FlashblocksPayloadV1, Metadata as FlashblockMetadata,
+};
+use serde::{Deserialize, Serialize};
+
+/// Block type for Optimism network.
+pub type OpBlock = alloy_rpc_types_eth::Block<op_alloy_rpc_types::Transaction>;
+
+/// Response from `base_meteredPriorityFeePerGas` RPC method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeteredPriorityFeeResponse {
+    /// Number of blocks sampled.
+    pub blocks_sampled: u64,
+    /// Suggested priority fee.
+    pub priority_fee: U256,
+}


### PR DESCRIPTION
## Summary

- Ports the flashblocks-e2e functional test suite (28 tests, 7 categories) into basectl as `crates/flashtest/`, following the same patterns as gobrr
- Tests cover: blocks, call, receipts, logs, subscriptions, metering, and contracts
- Configuration via YAML file (`--file/-f`), matching gobrr's interface
- Includes both TUI dashboard and headless `--logs` mode

Supersedes https://github.com/base/base/pull/348 — moves the test suite from base-reth-node into infra as an external tool that can target any chain.

## Usage

```bash
basectl flashtest --file config.yaml        # TUI mode
basectl flashtest --file config.yaml --logs  # headless/CI mode
```

Example `config.yaml`:
```yaml
rpc_url: "http://localhost:8545"
flashblocks_ws_url: "wss://mainnet.flashblocks.base.org/ws"
private_key: "0x..."       # optional, needed for tx-sending tests
recipient: "0x..."          # optional
simulator: "0x..."          # optional
filter: "blocks::*"         # optional glob pattern
```

## Test plan

- [ ] `cargo build -p flashtest` compiles standalone
- [ ] `cargo build -p basectl` compiles with flashtest integration
- [ ] `basectl flashtest --file config.yaml` launches TUI with live test progress
- [ ] Tests requiring signer/recipient/simulator show as SKIP when not configured
- [ ] `--logs` mode prints results to stdout for CI