### PR TITLE
feat:(basectl): More misc tui improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86debde32d8dbb0ab29e7cc75ae1a98688ac7a4c9da54b3a9b14593b9b3c46d3"
+checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6cb2e7efd385b333f5a77b71baaa2605f7e22f1d583f2879543b54cbce777c"
+checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668859fcdb42eee289de22a9d01758c910955bb6ecda675b97276f99ce2e16b0"
+checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ff5ee5f27aa305bda825c735f686ad71bb65508158f059f513895abe69b8c3"
+checksum = "e6ab1b2f1b48a7e6b3597cb2afae04f93879fb69d71e39736b5663d7366b23f2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be47bf1b91674a5f394b9ed3c691d764fb58ba43937f1371550ff4bc8e59c295"
+checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8708475665cc00e081c085886e68eada2f64cfa08fc668213a9231655093d4de"
+checksum = "1e414aa37b335ad2acb78a95814c59d137d53139b412f87aed1e10e2d862cd49"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a24c81a56d684f525cd1c012619815ad3a1dd13b0238f069356795d84647d3c"
+checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786c5b3ad530eaf43cda450f973fe7fb1c127b4c8990adf66709dafca25e3f6f"
+checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ed40adf21ae4be786ef5eb62db9c692f6a30f86d34452ca3f849d6390ce319"
+checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b88cf92ed20685979ed1d8472422f0c6c2d010cec77caf63aaa7669cc1a7bc2"
+checksum = "66b1483f8c2562bf35f0270b697d5b5fe8170464e935bd855a4c5eaf6f89b354"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ca4c15818be7ac86208aff3a91b951d14c24e1426e66624e75f2215ba5e2cc"
+checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eb9c9371738ac47f589e40aae6e418cb5f7436ad25b87575a7f94a60ccf43b"
+checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -378,14 +378,14 @@ checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe0addad5b8197e851062b49dc47157444bced173b601d91e3f9b561a060a50"
+checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d17d4645a717f0527e491f44f6f7a75c221b9c00ccf79ddba2d26c8e0df4c3"
+checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-txpool",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e98aabb013a71a4b67b52825f7b503e5bb6057fb3b7b2290d514b0b0574b57"
+checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc871ae69688e358cf242a6a7ee6b6e0476a03fd0256434c68daedaec086ec4"
+checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5899af8417dcf89f40f88fa3bdb2f3f172605d8e167234311ee34811bbfdb0bf"
+checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8074654c0292783d504bfa1f2691a69f420154ee9a7883f9212eaf611e60cd"
+checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb73325ee881e42972a5a7bc85250f6af89f92c6ad1222285f74384a203abeb"
+checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bea4c8f30eddb11d7ab56e83e49c814655daa78ca708df26c300c10d0189cbc"
+checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -508,23 +508,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fa1ca7e617c634d2bd9fa71f9ec8e47c07106e248b9fcbd3eaddc13cabd625"
+checksum = "2c4b64c8146291f750c3f391dff2dd40cf896f7e2b253417a31e342aa7265baa"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
+checksum = "d9df903674682f9bae8d43fdea535ab48df2d6a8cb5104ca29c58ada22ef67b3"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -534,15 +534,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.114",
+ "syn 2.0.115",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
+checksum = "737b8a959f527a86e07c44656db237024a32ae9b97d449f788262a547e8aa136"
 dependencies = [
  "const-hex",
  "dunce",
@@ -550,15 +550,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b91b13181d3bcd23680fd29d7bc861d1f33fbe90fdd0af67162434aeba902d"
+checksum = "b28e6e86c6d2db52654b65a5a76b4f57eae5a32a7f0aa2222d1dbdb74e2cb8e0"
 dependencies = [
  "serde",
  "winnow",
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc442cc2a75207b708d481314098a0f8b6f7b58e3148dd8d8cc7407b0d6f9385"
+checksum = "fdf7effe4ab0a4f52c865959f790036e61a7983f68b13b75d7fbcedf20b753ce"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b321f506bd67a434aae8e8a7dfe5373bf66137c149a5f09c9e7dfb0ca43d7c91"
+checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -601,12 +601,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bf12879a20e1261cd39c3b101856f52d18886907a826e102538897f0d2b66e"
+checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
+ "itertools 0.14.0",
  "opentelemetry",
  "opentelemetry-http",
  "reqwest",
@@ -619,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527a0d9c8bbc5c3215b03ad465d4ae8775384ff5faec7c41f033f087c851a9f9"
+checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -653,14 +654,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.6.1"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a91d6b4c2f6574fdbcb1611e460455c326667cf5b805c6bd1640dad8e8ee4d2"
+checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -833,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -871,7 +872,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -965,7 +966,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -976,7 +977,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1004,7 +1005,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1014,9 +1015,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base-flashtypes"
+name = "base-primitives"
 version = "0.0.0"
-source = "git+https://github.com/base/base.git#720f6e1a73faabc938402b0cb617d3960db742d4"
+source = "git+https://github.com/base/base.git#93a5bc63ccd8c01dba581ca4eddb162dc6c3787a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -1069,7 +1070,7 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "arboard",
- "base-flashtypes",
+ "base-primitives",
  "chrono",
  "crossterm",
  "dirs",
@@ -1182,7 +1183,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1262,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3075f133bee430b7644c54fb629b9b4420346ffa275a45c81a6babe8b09b4f51"
+checksum = "d7aff0c323415907f37007d645d7499c378df47efb3e33ffc1f397fa4e549b2e"
 dependencies = [
  "crossbeam-channel",
 ]
@@ -1322,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1332,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1351,14 +1352,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clipboard-win"
@@ -1585,7 +1586,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1598,7 +1599,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1609,7 +1610,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1620,7 +1621,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1655,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -1693,7 +1694,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.115",
  "unicode-xid",
 ]
 
@@ -1757,7 +1758,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1802,7 +1803,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1851,7 +1852,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1921,7 +1922,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2075,7 +2076,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2158,6 +2159,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2465,6 +2479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,7 +2542,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2567,7 +2587,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2690,10 +2710,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.181"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libm"
@@ -2770,7 +2796,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2938,7 +2964,7 @@ checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3116,7 +3142,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3194,7 +3220,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3279,7 +3305,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3348,6 +3374,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3386,7 +3422,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3532,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ec30b38a417407efe7676bad0ca6b78f995f810185ece9af3bd5dc561185a9"
+checksum = "84816e4c99c467e92cf984ee6328caa976dfecd33a673544489d79ca2caaefe5"
 dependencies = [
  "rustversion",
 ]
@@ -3597,7 +3633,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3830,9 +3866,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
@@ -3989,7 +4025,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4045,7 +4081,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4296,7 +4332,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4308,7 +4344,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4330,9 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4341,14 +4377,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379beea9476b89d0237078be761cf8e012d92d5ae4ae0c9a329f974838870fc"
+checksum = "f8658017776544996edc21c8c7cc8bb4f13db60955382f4bac25dc6303b38438"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4368,7 +4404,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4379,12 +4415,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -4407,7 +4443,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4508,7 +4544,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4597,9 +4633,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
 dependencies = [
  "winnow",
 ]
@@ -4668,7 +4704,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4795,9 +4831,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4929,6 +4965,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4974,7 +5019,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
  "wasm-bindgen-shared",
 ]
 
@@ -4985,6 +5030,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -5088,7 +5167,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5099,7 +5178,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5305,6 +5384,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.115",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -5376,7 +5537,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
  "synstructure",
 ]
 
@@ -5397,7 +5558,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5417,7 +5578,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
  "synstructure",
 ]
 
@@ -5438,7 +5599,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5471,14 +5632,14 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,5 +93,5 @@ op-alloy-rpc-types-engine = { version = "0.22.0", default-features = false }
 op-alloy-consensus = { version = "0.22.0", default-features = false }
 
 # base
-base-flashtypes = { git = "https://github.com/base/base.git" }
+base-primitives = { git = "https://github.com/base/base.git", features = ["flashblocks"] }
 basectl-cli = { path = "crates/basectl" }

--- a/crates/basectl/Cargo.toml
+++ b/crates/basectl/Cargo.toml
@@ -24,7 +24,7 @@ alloy-rpc-types-eth = { workspace = true }
 alloy-eips = { workspace = true }
 op-alloy-network = { workspace = true }
 op-alloy-consensus = { workspace = true }
-base-flashtypes = { workspace = true }
+base-primitives = { workspace = true }
 url = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }

--- a/crates/basectl/src/app/resources.rs
+++ b/crates/basectl/src/app/resources.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use base_flashtypes::Flashblock;
+use base_primitives::Flashblock;
 use tokio::sync::mpsc;
 
 use crate::{

--- a/crates/basectl/src/app/resources.rs
+++ b/crates/basectl/src/app/resources.rs
@@ -11,7 +11,7 @@ use crate::{
     tui::ToastState,
 };
 
-const MAX_FLASHBLOCKS: usize = 100;
+const MAX_FLASH_BLOCKS: usize = 30;
 
 #[derive(Debug)]
 pub struct Resources {
@@ -275,7 +275,7 @@ impl Default for FlashState {
 impl FlashState {
     pub fn new() -> Self {
         Self {
-            entries: VecDeque::with_capacity(MAX_FLASHBLOCKS),
+            entries: VecDeque::with_capacity(MAX_FLASH_BLOCKS * 10),
             current_block: None,
             current_gas_limit: 0,
             current_base_fee: None,
@@ -305,6 +305,23 @@ impl FlashState {
         for tsf in flashblocks {
             self.add_flashblock(tsf);
         }
+    }
+
+    fn evict_old_blocks(&mut self) {
+        let mut distinct = 0usize;
+        let mut last_block = None;
+        let mut keep = self.entries.len();
+        for (i, entry) in self.entries.iter().enumerate() {
+            if last_block != Some(entry.block_number) {
+                distinct += 1;
+                last_block = Some(entry.block_number);
+                if distinct > MAX_FLASH_BLOCKS {
+                    keep = i;
+                    break;
+                }
+            }
+        }
+        self.entries.truncate(keep);
     }
 
     pub fn add_flashblock(&mut self, tsf: TimestampedFlashblock) {
@@ -349,8 +366,6 @@ impl FlashState {
         };
 
         self.entries.push_front(entry);
-        if self.entries.len() > MAX_FLASHBLOCKS {
-            self.entries.pop_back();
-        }
+        self.evict_old_blocks();
     }
 }

--- a/crates/basectl/src/app/runner.rs
+++ b/crates/basectl/src/app/runner.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use base_flashtypes::Flashblock;
+use base_primitives::Flashblock;
 use tokio::sync::mpsc;
 
 use super::{App, Resources, ViewId, views::create_view};

--- a/crates/basectl/src/app/views/command_center.rs
+++ b/crates/basectl/src/app/views/command_center.rs
@@ -11,10 +11,10 @@ use ratatui::{
 use crate::{
     app::{Action, Resources, View},
     commands::common::{
-        COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, L1BlockFilter, L1_BLOCK_WINDOW,
-        RATE_WINDOW_2M, backlog_size_color, build_gas_bar, format_bytes, format_duration,
-        format_gwei, format_rate, render_da_backlog_bar, render_l1_blocks_table,
-        target_usage_color, time_diff_color, truncate_block_number,
+        COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, L1_BLOCK_WINDOW, L1BlockFilter, RATE_WINDOW_2M,
+        backlog_size_color, build_gas_bar, format_bytes, format_duration, format_gwei, format_rate,
+        render_da_backlog_bar, render_l1_blocks_table, target_usage_color, time_diff_color,
+        truncate_block_number,
     },
     tui::{Keybinding, Toast},
 };
@@ -87,7 +87,7 @@ impl CommandCenterView {
         };
     }
 
-    fn active_table_state(&mut self) -> &mut TableState {
+    const fn active_table_state(&mut self) -> &mut TableState {
         match self.focused_panel {
             Panel::Flashblocks => &mut self.flash_table_state,
             Panel::Da => &mut self.da_table_state,
@@ -106,15 +106,8 @@ impl CommandCenterView {
     fn update_highlighted_block(&mut self, resources: &Resources) {
         let row = self.selected_row(self.focused_panel);
         self.highlighted_block = match self.focused_panel {
-            Panel::Flashblocks => {
-                resources.flash.entries.get(row).map(|e| e.block_number)
-            }
-            Panel::Da => resources
-                .da
-                .tracker
-                .block_contributions
-                .get(row)
-                .map(|c| c.block_number),
+            Panel::Flashblocks => resources.flash.entries.get(row).map(|e| e.block_number),
+            Panel::Da => resources.da.tracker.block_contributions.get(row).map(|c| c.block_number),
             Panel::L1Blocks => None,
         };
     }
@@ -122,11 +115,9 @@ impl CommandCenterView {
     fn get_copyable_block(&self, resources: &Resources) -> Option<String> {
         let row = self.selected_row(self.focused_panel);
         match self.focused_panel {
-            Panel::Flashblocks => resources
-                .flash
-                .entries
-                .get(row)
-                .map(|e| e.block_number.to_string()),
+            Panel::Flashblocks => {
+                resources.flash.entries.get(row).map(|e| e.block_number.to_string())
+            }
             Panel::Da => resources
                 .da
                 .tracker
@@ -190,10 +181,10 @@ impl View for CommandCenterView {
                     Panel::Da => &mut self.da_table_state,
                     Panel::L1Blocks => &mut self.l1_table_state,
                 };
-                if let Some(selected) = state.selected() {
-                    if selected > 0 {
-                        state.select(Some(selected - 1));
-                    }
+                if let Some(selected) = state.selected()
+                    && selected > 0
+                {
+                    state.select(Some(selected - 1));
                 }
                 self.update_highlighted_block(resources);
                 Action::None
@@ -218,10 +209,10 @@ impl View for CommandCenterView {
                             .saturating_sub(1),
                     ),
                 };
-                if let Some(selected) = state.selected() {
-                    if selected < max {
-                        state.select(Some(selected + 1));
-                    }
+                if let Some(selected) = state.selected()
+                    && selected < max
+                {
+                    state.select(Some(selected + 1));
                 }
                 self.update_highlighted_block(resources);
                 Action::None

--- a/crates/basectl/src/app/views/command_center.rs
+++ b/crates/basectl/src/app/views/command_center.rs
@@ -307,7 +307,7 @@ impl View for CommandCenterView {
             panel_chunks[0],
             resources,
             self.focused_panel == Panel::Flashblocks,
-            &mut self.flash_table_state,
+            &self.flash_table_state,
             self.highlighted_block,
         );
 
@@ -316,7 +316,7 @@ impl View for CommandCenterView {
             panel_chunks[1],
             resources,
             self.focused_panel == Panel::Da,
-            &mut self.da_table_state,
+            &self.da_table_state,
             self.highlighted_block,
         );
 
@@ -409,42 +409,12 @@ fn render_stats_panel(f: &mut Frame, area: Rect, resources: &Resources) {
 
     let lines = vec![
         Line::from(vec![
-            Span::styled("DA: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format_bytes(tracker.da_backlog_bytes),
-                Style::default().fg(backlog_color),
-            ),
-            Span::raw("  "),
-            Span::styled("↑", Style::default().fg(COLOR_GROWTH)),
-            Span::styled(format_rate(growth_rate), Style::default().fg(COLOR_GROWTH)),
-            Span::raw(" "),
-            Span::styled("↓", Style::default().fg(COLOR_BURN)),
-            Span::styled(format_rate(burn_rate), Style::default().fg(COLOR_BURN)),
-            Span::raw("  "),
-            Span::styled("L1: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                target_usage.map_or_else(|| "-".to_string(), |u| format!("{:.0}%", u * 100.0)),
-                Style::default().fg(target_usage.map_or(Color::DarkGray, target_usage_color)),
-            ),
-            Span::raw(" "),
-            Span::styled("Base: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                base_share.map_or_else(|| "-".to_string(), |s| format!("{:.0}%", s * 100.0)),
-                Style::default().fg(COLOR_BASE_BLUE),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("Last: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                time_since.map(format_duration).unwrap_or_else(|| "-".to_string()),
-                Style::default().fg(Color::White),
-            ),
-            Span::raw("  "),
             Span::styled("Flash: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
                 resources.flash.message_count.to_string(),
                 Style::default().fg(Color::White),
             ),
+            Span::styled(flash_status, Style::default().fg(Color::Yellow)),
             Span::raw("  "),
             Span::styled("Missed: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
@@ -455,7 +425,37 @@ fn render_stats_panel(f: &mut Frame, area: Rect, resources: &Resources) {
                     Color::Green
                 }),
             ),
-            Span::styled(flash_status, Style::default().fg(Color::Yellow)),
+            Span::raw("  "),
+            Span::styled("↑", Style::default().fg(COLOR_GROWTH)),
+            Span::styled(format_rate(growth_rate), Style::default().fg(COLOR_GROWTH)),
+            Span::raw(" "),
+            Span::styled("↓", Style::default().fg(COLOR_BURN)),
+            Span::styled(format_rate(burn_rate), Style::default().fg(COLOR_BURN)),
+        ]),
+        Line::from(vec![
+            Span::styled("DA: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format_bytes(tracker.da_backlog_bytes),
+                Style::default().fg(backlog_color),
+            ),
+            Span::raw("  "),
+            Span::styled("L1: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                target_usage.map_or_else(|| "-".to_string(), |u| format!("{:.0}%", u * 100.0)),
+                Style::default().fg(target_usage.map_or(Color::DarkGray, target_usage_color)),
+            ),
+            Span::raw("  "),
+            Span::styled("Base: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                base_share.map_or_else(|| "-".to_string(), |s| format!("{:.0}%", s * 100.0)),
+                Style::default().fg(COLOR_BASE_BLUE),
+            ),
+            Span::raw("  "),
+            Span::styled("Last: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                time_since.map(format_duration).unwrap_or_else(|| "-".to_string()),
+                Style::default().fg(Color::White),
+            ),
         ]),
     ];
 
@@ -473,7 +473,7 @@ fn render_da_panel(
     area: Rect,
     resources: &Resources,
     is_active: bool,
-    table_state: &mut TableState,
+    table_state: &TableState,
     highlighted_block: Option<u64>,
 ) {
     let tracker = &resources.da.tracker;
@@ -545,7 +545,7 @@ fn render_flash_panel(
     area: Rect,
     resources: &Resources,
     is_active: bool,
-    table_state: &mut TableState,
+    table_state: &TableState,
     highlighted_block: Option<u64>,
 ) {
     let flash = &resources.flash;

--- a/crates/basectl/src/app/views/da_monitor.rs
+++ b/crates/basectl/src/app/views/da_monitor.rs
@@ -170,7 +170,7 @@ impl View for DaMonitorView {
             panel_chunks[0],
             resources,
             self.selected_panel == Panel::L2Blocks,
-            &mut self.l2_table_state,
+            &self.l2_table_state,
         );
 
         render_l1_blocks_table(
@@ -264,7 +264,7 @@ fn render_blocks_panel(
     area: Rect,
     resources: &Resources,
     is_active: bool,
-    table_state: &mut TableState,
+    table_state: &TableState,
 ) {
     use ratatui::widgets::{Cell, Row, Table};
 

--- a/crates/basectl/src/app/views/da_monitor.rs
+++ b/crates/basectl/src/app/views/da_monitor.rs
@@ -4,15 +4,15 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     prelude::*,
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Paragraph, TableState},
 };
 
 use crate::{
     app::{Action, Resources, View},
     commands::common::{
-        COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, L1BlockFilter, RATE_WINDOW_2M, RATE_WINDOW_5M,
-        RATE_WINDOW_30S, format_duration, format_rate, render_da_backlog_bar,
-        render_l1_blocks_table, truncate_block_number,
+        COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, L1_BLOCK_WINDOW, L1BlockFilter, RATE_WINDOW_2M,
+        RATE_WINDOW_5M, RATE_WINDOW_30S, format_duration, format_rate, render_da_backlog_bar,
+        render_l1_blocks_table, target_usage_color, truncate_block_number,
     },
     tui::Keybinding,
 };
@@ -21,6 +21,7 @@ const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "Esc", description: "Back to home" },
     Keybinding { key: "?", description: "Toggle help" },
     Keybinding { key: "↑/k ↓/j", description: "Navigate" },
+    Keybinding { key: "g/G", description: "Top/Bottom" },
     Keybinding { key: "←/h →/l", description: "Switch panel" },
     Keybinding { key: "Tab", description: "Next panel" },
     Keybinding { key: "f", description: "Filter L1 blocks" },
@@ -35,7 +36,8 @@ enum Panel {
 #[derive(Debug)]
 pub struct DaMonitorView {
     selected_panel: Panel,
-    selected_row: usize,
+    l2_table_state: TableState,
+    l1_table_state: TableState,
     l1_filter: L1BlockFilter,
 }
 
@@ -46,17 +48,32 @@ impl Default for DaMonitorView {
 }
 
 impl DaMonitorView {
-    pub const fn new() -> Self {
-        Self { selected_panel: Panel::L2Blocks, selected_row: 0, l1_filter: L1BlockFilter::All }
+    pub fn new() -> Self {
+        let mut l2_table_state = TableState::default();
+        l2_table_state.select(Some(0));
+        let mut l1_table_state = TableState::default();
+        l1_table_state.select(Some(0));
+        Self {
+            selected_panel: Panel::L2Blocks,
+            l2_table_state,
+            l1_table_state,
+            l1_filter: L1BlockFilter::All,
+        }
     }
 
-    #[allow(clippy::missing_const_for_fn)]
+    fn active_table_state(&mut self) -> &mut TableState {
+        match self.selected_panel {
+            Panel::L2Blocks => &mut self.l2_table_state,
+            Panel::L1Blocks => &mut self.l1_table_state,
+        }
+    }
+
     fn next_panel(&mut self) {
         self.selected_panel = match self.selected_panel {
             Panel::L2Blocks => Panel::L1Blocks,
             Panel::L1Blocks => Panel::L2Blocks,
         };
-        self.selected_row = 0;
+        self.active_table_state().select(Some(0));
     }
 
     fn panel_len(&self, panel: Panel, resources: &Resources) -> usize {
@@ -75,15 +92,21 @@ impl View for DaMonitorView {
     fn handle_key(&mut self, key: KeyEvent, resources: &mut Resources) -> Action {
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
-                if self.selected_row > 0 {
-                    self.selected_row -= 1;
+                let state = self.active_table_state();
+                if let Some(selected) = state.selected() {
+                    if selected > 0 {
+                        state.select(Some(selected - 1));
+                    }
                 }
                 Action::None
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 let max = self.panel_len(self.selected_panel, resources).saturating_sub(1);
-                if self.selected_row < max {
-                    self.selected_row += 1;
+                let state = self.active_table_state();
+                if let Some(selected) = state.selected() {
+                    if selected < max {
+                        state.select(Some(selected + 1));
+                    }
                 }
                 Action::None
             }
@@ -97,7 +120,16 @@ impl View for DaMonitorView {
             }
             KeyCode::Char('f') => {
                 self.l1_filter = self.l1_filter.next();
-                self.selected_row = 0;
+                self.l1_table_state.select(Some(0));
+                Action::None
+            }
+            KeyCode::Char('g') => {
+                self.active_table_state().select(Some(0));
+                Action::None
+            }
+            KeyCode::Char('G') => {
+                let max = self.panel_len(self.selected_panel, resources).saturating_sub(1);
+                self.active_table_state().select(Some(max));
                 Action::None
             }
             _ => Action::None,
@@ -110,8 +142,9 @@ impl View for DaMonitorView {
             .constraints([Constraint::Length(3), Constraint::Length(5), Constraint::Min(0)])
             .split(area);
 
+        let l2_selected = self.l2_table_state.selected().unwrap_or(0);
         let highlighted_block = if self.selected_panel == Panel::L2Blocks {
-            resources.da.tracker.block_contributions.get(self.selected_row).map(|c| c.block_number)
+            resources.da.tracker.block_contributions.get(l2_selected).map(|c| c.block_number)
         } else {
             None
         };
@@ -137,7 +170,7 @@ impl View for DaMonitorView {
             panel_chunks[0],
             resources,
             self.selected_panel == Panel::L2Blocks,
-            self.selected_row,
+            &mut self.l2_table_state,
         );
 
         render_l1_blocks_table(
@@ -145,7 +178,7 @@ impl View for DaMonitorView {
             panel_chunks[1],
             resources.da.tracker.filtered_l1_blocks(self.l1_filter),
             self.selected_panel == Panel::L1Blocks,
-            if self.selected_panel == Panel::L1Blocks { self.selected_row } else { 0 },
+            &mut self.l1_table_state,
             self.l1_filter,
             "L1 Blocks",
             resources.da.l1_connection_mode,
@@ -168,9 +201,8 @@ fn render_stats_panel(f: &mut Frame, area: Rect, resources: &Resources, filter: 
     let burn_2m = tracker.burn_tracker.rate_over(RATE_WINDOW_2M);
     let burn_5m = tracker.burn_tracker.rate_over(RATE_WINDOW_5M);
 
-    let base_share_2m = tracker.base_blob_share(RATE_WINDOW_2M);
-    let target_usage_2m =
-        tracker.blob_target_usage(RATE_WINDOW_2M, resources.config.l1_blob_target);
+    let base_share = tracker.base_blob_share(L1_BLOCK_WINDOW);
+    let target_usage = tracker.blob_target_usage(L1_BLOCK_WINDOW, resources.config.l1_blob_target);
 
     let time_since = tracker.last_base_blob_time.map(|t| t.elapsed());
 
@@ -199,10 +231,13 @@ fn render_stats_panel(f: &mut Frame, area: Rect, resources: &Resources, filter: 
         ]),
         Line::from(vec![
             Span::styled("L1 Target: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_share(target_usage_2m), Style::default().fg(Color::Yellow)),
+            Span::styled(
+                format_share(target_usage),
+                Style::default().fg(target_usage.map_or(Color::DarkGray, target_usage_color)),
+            ),
             Span::raw("  "),
             Span::styled("Base: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_share(base_share_2m), Style::default().fg(COLOR_BASE_BLUE)),
+            Span::styled(format_share(base_share), Style::default().fg(COLOR_BASE_BLUE)),
             Span::raw("  "),
             Span::styled("Last: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
@@ -229,7 +264,7 @@ fn render_blocks_panel(
     area: Rect,
     resources: &Resources,
     is_active: bool,
-    selected_row: usize,
+    table_state: &mut TableState,
 ) {
     use ratatui::widgets::{Cell, Row, Table};
 
@@ -248,7 +283,6 @@ fn render_blocks_panel(
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    // DA(8) + Age(6) + spacing(3) = 17
     let fixed_cols_width = 8 + 6 + 3;
     let block_col_width = inner.width.saturating_sub(fixed_cols_width).clamp(4, 10) as usize;
 
@@ -259,13 +293,14 @@ fn render_blocks_panel(
         Cell::from("Age").style(header_style),
     ]);
 
+    let selected_row = table_state.selected();
+
     let rows: Vec<Row> = tracker
         .block_contributions
         .iter()
-        .take(inner.height.saturating_sub(1) as usize)
         .enumerate()
         .map(|(idx, contrib)| {
-            let is_selected = is_active && idx == selected_row;
+            let is_selected = is_active && selected_row == Some(idx);
             let is_safe = contrib.block_number <= tracker.safe_l2_block;
 
             let style = if is_selected {
@@ -292,5 +327,5 @@ fn render_blocks_panel(
 
     let widths = [Constraint::Max(10), Constraint::Length(8), Constraint::Min(6)];
     let table = Table::new(rows, widths).header(header);
-    f.render_widget(table, inner);
+    f.render_stateful_widget(table, inner, &mut table_state.clone());
 }

--- a/crates/basectl/src/app/views/da_monitor.rs
+++ b/crates/basectl/src/app/views/da_monitor.rs
@@ -61,7 +61,7 @@ impl DaMonitorView {
         }
     }
 
-    fn active_table_state(&mut self) -> &mut TableState {
+    const fn active_table_state(&mut self) -> &mut TableState {
         match self.selected_panel {
             Panel::L2Blocks => &mut self.l2_table_state,
             Panel::L1Blocks => &mut self.l1_table_state,
@@ -93,20 +93,20 @@ impl View for DaMonitorView {
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
                 let state = self.active_table_state();
-                if let Some(selected) = state.selected() {
-                    if selected > 0 {
-                        state.select(Some(selected - 1));
-                    }
+                if let Some(selected) = state.selected()
+                    && selected > 0
+                {
+                    state.select(Some(selected - 1));
                 }
                 Action::None
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 let max = self.panel_len(self.selected_panel, resources).saturating_sub(1);
                 let state = self.active_table_state();
-                if let Some(selected) = state.selected() {
-                    if selected < max {
-                        state.select(Some(selected + 1));
-                    }
+                if let Some(selected) = state.selected()
+                    && selected < max
+                {
+                    state.select(Some(selected + 1));
                 }
                 Action::None
             }

--- a/crates/basectl/src/app/views/flashblocks.rs
+++ b/crates/basectl/src/app/views/flashblocks.rs
@@ -1,7 +1,7 @@
 use arboard::Clipboard;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
-    layout::{Constraint, Rect},
+    layout::{Constraint, Direction, Layout, Rect},
     prelude::*,
     widgets::{Block, Borders, Cell, Row, Table, TableState},
 };
@@ -9,8 +9,9 @@ use ratatui::{
 use crate::{
     app::{Action, Resources, View},
     commands::common::{
-        COLOR_ACTIVE_BORDER, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, build_gas_bar, format_gas,
-        format_gwei, time_diff_color, truncate_block_number,
+        COLOR_ACTIVE_BORDER, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, block_color,
+        block_color_bright, build_gas_bar, format_gas, format_gwei, render_gas_usage_bar,
+        time_diff_color, truncate_block_number,
     },
     tui::{Keybinding, Toast},
 };
@@ -136,6 +137,27 @@ impl View for FlashblocksView {
     fn render(&mut self, frame: &mut Frame, area: Rect, resources: &Resources) {
         let flash = &resources.flash;
 
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(3), Constraint::Min(0)])
+            .split(area);
+
+        let highlighted_block = self
+            .table_state
+            .selected()
+            .and_then(|idx| flash.entries.get(idx))
+            .map(|e| e.block_number);
+
+        render_gas_usage_bar(
+            frame,
+            chunks[0],
+            &flash.entries,
+            DEFAULT_ELASTICITY,
+            highlighted_block,
+        );
+
+        let table_area = chunks[1];
+
         let missed = resources.flash.missed_flashblocks;
         let missed_str = if missed > 0 { format!(" | {missed} missed") } else { String::new() };
         let title = if flash.paused {
@@ -151,14 +173,8 @@ impl View for FlashblocksView {
             .borders(Borders::ALL)
             .border_style(Style::default().fg(border_color));
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-
-        let highlighted_block = self
-            .table_state
-            .selected()
-            .and_then(|idx| flash.entries.get(idx))
-            .map(|e| e.block_number);
+        let inner = block.inner(table_area);
+        frame.render_widget(block, table_area);
 
         // Idx(4) + Txs(4) + Gas(7) + BaseFee(12) + Delta(8) + Dt(8) + Fill(42) + Time(8) + spacing = ~100
         let fixed_cols_width = 4 + 4 + 7 + 12 + 8 + 8 + (GAS_BAR_CHARS as u16 + 2) + 8 + 9;
@@ -236,19 +252,21 @@ impl View for FlashblocksView {
                     |ms| (format!("+{ms}ms"), Style::default().fg(time_diff_color(ms))),
                 );
 
-                let first_fb_style = if entry.index == 0 {
-                    Style::default().fg(Color::Green)
+                let block_style = if entry.index == 0 {
+                    Style::default()
+                        .fg(block_color_bright(entry.block_number))
+                        .add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Color::White)
+                    Style::default().fg(block_color(entry.block_number))
                 };
 
                 let time_str = entry.timestamp.format("%H:%M:%S").to_string();
 
                 Row::new(vec![
                     Cell::from(truncate_block_number(entry.block_number, block_col_width))
-                        .style(first_fb_style),
-                    Cell::from(entry.index.to_string()).style(first_fb_style),
-                    Cell::from(entry.tx_count.to_string()).style(first_fb_style),
+                        .style(block_style),
+                    Cell::from(entry.index.to_string()).style(block_style),
+                    Cell::from(entry.tx_count.to_string()).style(block_style),
                     Cell::from(format_gas(entry.gas_used)),
                     Cell::from(base_fee_str).style(base_fee_style),
                     Cell::from(delta_str).style(delta_style),

--- a/crates/basectl/src/app/views/flashblocks.rs
+++ b/crates/basectl/src/app/views/flashblocks.rs
@@ -12,7 +12,7 @@ use crate::{
         COLOR_ACTIVE_BORDER, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, build_gas_bar, format_gas,
         format_gwei, time_diff_color, truncate_block_number,
     },
-    tui::Keybinding,
+    tui::{Keybinding, Toast},
 };
 
 const GAS_BAR_CHARS: usize = 40;
@@ -115,7 +115,10 @@ impl View for FlashblocksView {
                     && let Some(entry) = resources.flash.entries.get(idx)
                     && let Ok(mut clipboard) = Clipboard::new()
                 {
-                    let _ = clipboard.set_text(entry.block_number.to_string());
+                    let block_num = entry.block_number.to_string();
+                    if clipboard.set_text(&block_num).is_ok() {
+                        resources.toasts.push(Toast::info(format!("Copied {block_num}")));
+                    }
                 }
                 Action::None
             }

--- a/crates/basectl/src/commands/common.rs
+++ b/crates/basectl/src/commands/common.rs
@@ -889,10 +889,11 @@ pub fn render_gas_usage_bar(
     let mut block_gas: Vec<(u64, u64)> = Vec::new();
     for entry in entries {
         if let Some(last) = block_gas.last_mut()
-            && last.0 == entry.block_number {
-                last.1 = last.1.max(entry.gas_used);
-                continue;
-            }
+            && last.0 == entry.block_number
+        {
+            last.1 = last.1.max(entry.gas_used);
+            continue;
+        }
         block_gas.push((entry.block_number, entry.gas_used));
     }
 

--- a/crates/basectl/src/commands/common.rs
+++ b/crates/basectl/src/commands/common.rs
@@ -888,12 +888,11 @@ pub fn render_gas_usage_bar(
 ) {
     let mut block_gas: Vec<(u64, u64)> = Vec::new();
     for entry in entries {
-        if let Some(last) = block_gas.last_mut() {
-            if last.0 == entry.block_number {
+        if let Some(last) = block_gas.last_mut()
+            && last.0 == entry.block_number {
                 last.1 = last.1.max(entry.gas_used);
                 continue;
             }
-        }
         block_gas.push((entry.block_number, entry.gas_used));
     }
 

--- a/crates/basectl/src/commands/common.rs
+++ b/crates/basectl/src/commands/common.rs
@@ -594,6 +594,27 @@ pub const fn block_color(block_number: u64) -> Color {
     BLOCK_COLORS[(block_number as usize) % BLOCK_COLORS.len()]
 }
 
+pub const fn block_color_bright(block_number: u64) -> Color {
+    let Color::Rgb(r, g, b) = BLOCK_COLORS[(block_number as usize) % BLOCK_COLORS.len()] else {
+        unreachable!()
+    };
+    Color::Rgb(
+        r.saturating_add((255 - r) / 2),
+        g.saturating_add((255 - g) / 2),
+        b.saturating_add((255 - b) / 2),
+    )
+}
+
+const fn dim_color(color: Color, opacity: f64) -> Color {
+    let Color::Rgb(r, g, b) = color else {
+        return color;
+    };
+    Color::Rgb((r as f64 * opacity) as u8, (g as f64 * opacity) as u8, (b as f64 * opacity) as u8)
+}
+
+const GAS_COLOR_WARM: (u8, u8, u8) = (255, 200, 80);
+const GAS_COLOR_HOT: (u8, u8, u8) = (255, 60, 60);
+
 pub fn build_gas_bar(
     gas_used: u64,
     gas_limit: u64,
@@ -608,34 +629,55 @@ pub fn build_gas_bar(
     let gas_target = gas_limit / elasticity;
     let target_char = ((gas_target as f64 / gas_limit as f64) * bar_chars as f64).round() as usize;
 
-    let filled_units = ((gas_used as f64 / gas_limit as f64) * bar_units as f64).round() as usize;
+    let filled_units = ((gas_used as f64 / gas_limit as f64) * bar_units as f64).ceil() as usize;
     let filled_units = filled_units.min(bar_units);
 
-    let fill_color = COLOR_GAS_FILL;
-    let target_color = COLOR_TARGET;
+    let target_units = target_char * 8;
+    let excess_chars = bar_chars.saturating_sub(target_char).max(1);
+
+    let excess_color = |char_idx: usize| -> Color {
+        let t = (char_idx - target_char) as f64 / excess_chars as f64;
+        lerp_rgb(GAS_COLOR_WARM, GAS_COLOR_HOT, t.clamp(0.0, 1.0))
+    };
 
     let mut spans = Vec::new();
     let mut current_units = 0;
 
     for char_idx in 0..bar_chars {
         let char_end_units = (char_idx + 1) * 8;
-        let is_target_char = char_idx == target_char;
 
-        if is_target_char {
-            if current_units >= filled_units {
-                spans.push(Span::styled("│", Style::default().fg(target_color)));
+        if char_idx == target_char {
+            if filled_units <= target_units {
+                spans.push(Span::styled("▏", Style::default().fg(COLOR_TARGET)));
             } else {
-                spans.push(Span::styled("│", Style::default().fg(target_color).bg(fill_color)));
+                let over_units = filled_units.saturating_sub(target_units).min(8);
+                let color = excess_color(char_idx);
+                if over_units >= 8 {
+                    spans.push(Span::styled("█", Style::default().fg(color)));
+                } else {
+                    let opacity = over_units as f64 / 8.0;
+                    let dimmed = dim_color(color, opacity);
+                    spans.push(Span::styled(
+                        EIGHTH_BLOCKS[over_units - 1].to_string(),
+                        Style::default().fg(dimmed),
+                    ));
+                }
             }
         } else if current_units >= filled_units {
-            spans.push(Span::styled(" ", Style::default()));
+            spans.push(Span::raw(" "));
         } else if char_end_units <= filled_units {
+            let fill_color =
+                if char_idx < target_char { COLOR_GAS_FILL } else { excess_color(char_idx) };
             spans.push(Span::styled("█", Style::default().fg(fill_color)));
         } else {
             let units_in_char = filled_units - current_units;
+            let opacity = units_in_char as f64 / 8.0;
+            let fill_color =
+                if char_idx < target_char { COLOR_GAS_FILL } else { excess_color(char_idx) };
+            let dimmed = dim_color(fill_color, opacity);
             spans.push(Span::styled(
                 EIGHTH_BLOCKS[units_in_char - 1].to_string(),
-                Style::default().fg(fill_color),
+                Style::default().fg(dimmed),
             ));
         }
 
@@ -830,6 +872,133 @@ pub fn render_da_backlog_bar(
     spans.push(Span::styled(
         format!(" {:>8}", format_bytes(total_backlog)),
         Style::default().fg(backlog_color).add_modifier(Modifier::BOLD),
+    ));
+
+    let line = Line::from(spans);
+    let para = Paragraph::new(line);
+    f.render_widget(para, inner);
+}
+
+pub fn render_gas_usage_bar(
+    f: &mut Frame,
+    area: Rect,
+    entries: &VecDeque<FlashblockEntry>,
+    elasticity: u64,
+    highlighted_block: Option<u64>,
+) {
+    let mut block_gas: Vec<(u64, u64)> = Vec::new();
+    for entry in entries {
+        if let Some(last) = block_gas.last_mut() {
+            if last.0 == entry.block_number {
+                last.1 = last.1.max(entry.gas_used);
+                continue;
+            }
+        }
+        block_gas.push((entry.block_number, entry.gas_used));
+    }
+
+    let n_label = block_gas.len();
+    let title_widget = Block::default()
+        .title(format!(" Gas Usage ({n_label} blocks) "))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let inner = title_widget.inner(area);
+    f.render_widget(title_widget, area);
+
+    if inner.width < 10 || inner.height < 1 {
+        return;
+    }
+
+    let bar_width = inner.width.saturating_sub(12) as usize;
+
+    if block_gas.is_empty() {
+        let empty_bar = "░".repeat(bar_width);
+        let text = format!("{empty_bar} {:>5}", "0%");
+        let para = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
+        f.render_widget(para, inner);
+        return;
+    }
+
+    let n_blocks = block_gas.len() as u64;
+    let gas_limit = entries.front().map(|e| e.gas_limit).unwrap_or(0);
+    let per_block_target = if elasticity > 0 && gas_limit > 0 { gas_limit / elasticity } else { 0 };
+    let total_target = per_block_target * n_blocks;
+    let total_limit = gas_limit * n_blocks;
+    let total_gas: u64 = block_gas.iter().map(|(_, g)| *g).sum();
+
+    let half = bar_width / 2;
+    let target_char = half;
+
+    let gas_to_chars = |gas: u64| -> f64 {
+        if total_target == 0 {
+            return 0.0;
+        }
+        let g = gas as f64;
+        let t = total_target as f64;
+        let l = total_limit as f64;
+        if g <= t {
+            (g / t) * half as f64
+        } else {
+            half as f64 + ((g - t) / (l - t)) * (bar_width - half) as f64
+        }
+    };
+
+    let mut spans: Vec<Span> = Vec::new();
+    let mut chars_used = 0usize;
+    let mut cumulative_gas = 0u64;
+
+    for &(block_number, gas_used) in block_gas.iter().rev() {
+        if chars_used >= bar_width {
+            break;
+        }
+
+        let color = block_color(block_number);
+        let is_highlighted = highlighted_block == Some(block_number);
+
+        let pos_before = gas_to_chars(cumulative_gas).round() as usize;
+        cumulative_gas += gas_used;
+        let pos_after = gas_to_chars(cumulative_gas).round() as usize;
+        let char_count = pos_after.saturating_sub(pos_before).max(1).min(bar_width - chars_used);
+
+        if char_count > 0 {
+            let style = if is_highlighted {
+                Style::default().fg(Color::White).bg(color)
+            } else {
+                Style::default().fg(color)
+            };
+            let glyph = if is_highlighted { "⣿" } else { "█" };
+
+            if target_char > chars_used && target_char < chars_used + char_count {
+                let before = target_char - chars_used;
+                let after = char_count - before - 1;
+                if before > 0 {
+                    spans.push(Span::styled(glyph.repeat(before), style));
+                }
+                spans.push(Span::styled("│", Style::default().fg(COLOR_TARGET).bg(color)));
+                if after > 0 {
+                    spans.push(Span::styled(glyph.repeat(after), style));
+                }
+            } else {
+                spans.push(Span::styled(glyph.repeat(char_count), style));
+            }
+            chars_used += char_count;
+        }
+    }
+
+    while chars_used < bar_width {
+        if chars_used == target_char {
+            spans.push(Span::styled("│", Style::default().fg(COLOR_TARGET)));
+        } else {
+            spans.push(Span::styled("░", Style::default().fg(Color::DarkGray)));
+        }
+        chars_used += 1;
+    }
+
+    let usage_ratio = if total_target > 0 { total_gas as f64 / total_target as f64 } else { 0.0 };
+    spans.push(Span::styled(
+        format!(" {:>5.0}%", usage_ratio * 100.0),
+        Style::default().fg(target_usage_color(usage_ratio)).add_modifier(Modifier::BOLD),
     ));
 
     let line = Line::from(spans);

--- a/crates/basectl/src/rpc.rs
+++ b/crates/basectl/src/rpc.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{Address, B256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionTrait};
 use anyhow::Result;
-use base_flashtypes::Flashblock;
+use base_primitives::Flashblock;
 use futures_util::{StreamExt, stream};
 use op_alloy_network::Optimism;
 use tokio::sync::mpsc;

--- a/crates/basectl/src/tui/toast.rs
+++ b/crates/basectl/src/tui/toast.rs
@@ -101,7 +101,10 @@ impl ToastState {
         self.toasts.retain(|t| !t.is_expired());
     }
 
-    /// Get the current active toast (most recent)
+    pub fn push(&mut self, toast: Toast) {
+        self.toasts.push(toast);
+    }
+
     pub fn current(&self) -> Option<&Toast> {
         self.toasts.last()
     }


### PR DESCRIPTION
* Calculate DA target usage based on L1 block times (up to 10), not elapsed time
* Use continuous color grading for DA target consumption (yellow at 100%)
* Support scrollable tables with vim nav (g/G)
* Add new gas usage bar spanning up to 30 blocks
* Improve rendering of the flashblock-level gas usage bars, using left-aligned pipe for target and variable color grading
* Color-code flashblock rows by L2 block
* Backfill L1 block gaps if websocket drops messages
* Add toast notification on block num copy
* Reorganize stats panel
<img width="1330" height="1088" alt="image" src="https://github.com/user-attachments/assets/30a6aee8-ed6a-48ab-afc3-47068c4b5b25" />
